### PR TITLE
Add SQLite tables command supporting list and csv format

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -45,7 +45,7 @@ jobs:
         run: rm -rf temp_dist version
 
       - name: Upload distribution as artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: wp-cli-sqlite-command-${{ env.RELEASE_VERSION }}
           path: wp-cli-sqlite-command-${{ env.RELEASE_VERSION }}.zip

--- a/README.md
+++ b/README.md
@@ -47,13 +47,10 @@ $ wp sqlite export [<file>] [--tables=<tables>] [--exclude-tables] [--porcelain]
 Lists the SQLite database tables.
 
 ```
-$ wp sqlite tables [--pattern=<pattern>] [--format=<list|csv>]
+$ wp sqlite tables [--format=<list|csv>]
 ```
 
 **OPTIONS**
-
-	[--pattern=<pattern>]
-		Filter the list of tables by a wildcard pattern.
 
 	[--format=<format>]
 		Render output in a specific format.
@@ -79,11 +76,6 @@ $ wp sqlite tables [--pattern=<pattern>] [--format=<list|csv>]
 	wp_comments
 	wp_links
 	wp_options
-	wp_postmeta
-	wp_posts
-
-    # List all tables matching a wildcard
-    $ wp sqlite tables "wp_post*"
 	wp_postmeta
 	wp_posts
 

--- a/README.md
+++ b/README.md
@@ -42,3 +42,52 @@ $ wp sqlite export [<file>] [--tables=<tables>] [--exclude-tables] [--porcelain]
 	[--porcelain]
 		Output filename for the exported database.
 
+### wp sqlite tables
+
+Lists the SQLite database tables.
+
+```
+$ wp sqlite tables [--pattern=<pattern>] [--format=<list|csv>]
+```
+
+**OPTIONS**
+
+	[--pattern=<pattern>]
+		Filter the list of tables by a wildcard pattern.
+
+	[--format=<format>]
+		Render output in a specific format.
+		---
+		Default: list
+		Options:
+			- list
+			- csv
+		---
+
+**EXAMPLES**
+
+```
+    # List all tables
+    $ wp sqlite tables
+	wp_users
+	wp_usermeta
+	wp_termmeta
+	wp_terms
+	wp_term_taxonomy
+	wp_term_relationships
+	wp_commentmeta
+	wp_comments
+	wp_links
+	wp_options
+	wp_postmeta
+	wp_posts
+
+    # List all tables matching a wildcard
+    $ wp sqlite tables "wp_post*"
+	wp_postmeta
+	wp_posts
+
+	* List all tables in CSV format
+	$ wp sqlite tables --format=csv
+	wp_users,wp_usermeta,wp_termmeta,wp_terms,wp_term_taxonomy,wp_term_relationships,wp_commentmeta,wp_comments,wp_links,wp_options,wp_postmeta,wp_posts
+```

--- a/src/SQLite_Command.php
+++ b/src/SQLite_Command.php
@@ -142,13 +142,13 @@ class SQLite_Command extends WP_CLI_Command {
 	 *
 	 * @when before_wp_load
 	 */
-	public function tables($args, $assoc_args) {
-		if (!Base::get_sqlite_plugin_version()) {
-			WP_CLI::error('The SQLite integration plugin is not installed or activated.');
+	public function tables( $args, $assoc_args ) {
+		if ( ! Base::get_sqlite_plugin_version() ) {
+			WP_CLI::error( 'The SQLite integration plugin is not installed or activated.' );
 		}
 
-		$tables = new Tables();
-		$pattern = !empty($args) ? $args[0] : null;
-		$tables->run($pattern, $assoc_args);
+		$tables  = new Tables();
+		$pattern = ! empty( $args ) ? $args[0] : null;
+		$tables->run( $pattern, $assoc_args );
 	}
 }

--- a/src/SQLite_Command.php
+++ b/src/SQLite_Command.php
@@ -135,8 +135,10 @@ class SQLite_Command extends WP_CLI_Command {
 	 *     wp_usermeta
 	 *     wp_users
 	 *
-	 *     # List all tables matching a wildcard
-	 *     $ wp sqlite tables wp_post*
+	 *     # List all tables matching wildcards
+	 *     $ wp sqlite tables wp_comment* wp_post*
+	 *     wp_commentmeta
+	 *     wp_comments
 	 *     wp_postmeta
 	 *     wp_posts
 	 *
@@ -147,8 +149,7 @@ class SQLite_Command extends WP_CLI_Command {
 			WP_CLI::error( 'The SQLite integration plugin is not installed or activated.' );
 		}
 
-		$tables  = new Tables();
-		$pattern = ! empty( $args ) ? $args[0] : null;
-		$tables->run( $pattern, $assoc_args );
+		$tables = new Tables();
+		$tables->run( $args, $assoc_args );
 	}
 }

--- a/src/SQLite_Command.php
+++ b/src/SQLite_Command.php
@@ -106,11 +106,9 @@ class SQLite_Command extends WP_CLI_Command {
 	 *
 	 * ## OPTIONS
 	 *
-	 * [<table>...]
-	 * : List tables based on wildcard search, e.g. 'wp_*_options' or 'wp_post?'.
-	 *
 	 * [--format=<format>]
 	 * : Render output in a particular format.
+	 *
 	 * ---
 	 * default: list
 	 * options:
@@ -135,13 +133,6 @@ class SQLite_Command extends WP_CLI_Command {
 	 *     wp_usermeta
 	 *     wp_users
 	 *
-	 *     # List all tables matching wildcards
-	 *     $ wp sqlite tables wp_comment* wp_post*
-	 *     wp_commentmeta
-	 *     wp_comments
-	 *     wp_postmeta
-	 *     wp_posts
-	 *
 	 * @when before_wp_load
 	 */
 	public function tables( $args, $assoc_args ) {
@@ -150,6 +141,6 @@ class SQLite_Command extends WP_CLI_Command {
 		}
 
 		$tables = new Tables();
-		$tables->run( $args, $assoc_args );
+		$tables->run( $assoc_args );
 	}
 }

--- a/src/SQLite_Command.php
+++ b/src/SQLite_Command.php
@@ -4,6 +4,7 @@ namespace Automattic\WP_CLI\SQLite;
 
 use WP_CLI;
 use WP_CLI_Command;
+use PDO;
 
 class SQLite_Command extends WP_CLI_Command {
 
@@ -96,5 +97,58 @@ class SQLite_Command extends WP_CLI_Command {
 		}
 
 		$export->run( $result_file, $assoc_args );
+	}
+
+	/**
+	 * Lists the database tables.
+	 *
+	 * Defaults to all tables in the SQLite database.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [<table>...]
+	 * : List tables based on wildcard search, e.g. 'wp_*_options' or 'wp_post?'.
+	 *
+	 * [--format=<format>]
+	 * : Render output in a particular format.
+	 * ---
+	 * default: list
+	 * options:
+	 *   - list
+	 *   - csv
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # List all tables in the database
+	 *     $ wp sqlite tables
+	 *     wp_commentmeta
+	 *     wp_comments
+	 *     wp_links
+	 *     wp_options
+	 *     wp_postmeta
+	 *     wp_posts
+	 *     wp_terms
+	 *     wp_termmeta
+	 *     wp_term_relationships
+	 *     wp_term_taxonomy
+	 *     wp_usermeta
+	 *     wp_users
+	 *
+	 *     # List all tables matching a wildcard
+	 *     $ wp sqlite tables wp_post*
+	 *     wp_postmeta
+	 *     wp_posts
+	 *
+	 * @when before_wp_load
+	 */
+	public function tables($args, $assoc_args) {
+		if (!Base::get_sqlite_plugin_version()) {
+			WP_CLI::error('The SQLite integration plugin is not installed or activated.');
+		}
+
+		$tables = new Tables();
+		$pattern = !empty($args) ? $args[0] : null;
+		$tables->run($pattern, $assoc_args);
 	}
 }

--- a/src/SQLite_Command.php
+++ b/src/SQLite_Command.php
@@ -4,7 +4,6 @@ namespace Automattic\WP_CLI\SQLite;
 
 use WP_CLI;
 use WP_CLI_Command;
-use PDO;
 
 class SQLite_Command extends WP_CLI_Command {
 

--- a/src/Tables.php
+++ b/src/Tables.php
@@ -6,15 +6,10 @@ use WP_CLI;
 use PDO;
 use WP_SQLite_Translator;
 
-/**
- * Class Tables
- * Handles listing tables in the SQLite database.
- */
 class Tables extends Base {
 
 	protected $translator;
 	protected $args      = array();
-	protected $is_stdout = false;
 
 	public function __construct() {
 		$this->load_dependencies();

--- a/src/Tables.php
+++ b/src/Tables.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Automattic\WP_CLI\SQLite;
+
+use WP_CLI;
+use PDO;
+use WP_SQLite_Translator;
+
+/**
+ * Class Tables
+ * Handles listing tables in the SQLite database.
+ */
+class Tables extends Base {
+
+	protected $translator;
+	protected $args      = array();
+	protected $is_stdout = false;
+
+	public function __construct() {
+		$this->load_dependencies();
+		$this->translator = new WP_SQLite_Translator();
+	}
+
+	/**
+	 * Get the PDO instance.
+	 *
+	 * @return PDO
+	 */
+	protected function get_pdo() {
+		return $this->translator->get_pdo();
+	}
+
+    /**
+     * Lists all tables in the SQLite database.
+     *
+     * @param string|null $pattern Optional wildcard pattern to filter tables.
+     * @param array $assoc_args Associative array of options.
+     * @return void
+     */
+    public function run($pattern = null, $assoc_args = []) {
+        $pdo = $this->get_pdo();
+
+        // Get all tables
+        $stmt = $pdo->query("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'");
+        $tables = $stmt->fetchAll(PDO::FETCH_COLUMN);
+
+        // Filter tables if wildcard pattern is provided
+        if ($pattern) {
+            $sql_pattern = str_replace('?', '_', $pattern);
+            $sql_pattern = str_replace('*', '%', $sql_pattern);
+
+            $tables = array_filter($tables, function($table) use ($pattern) {
+                return fnmatch($pattern, $table, FNM_CASEFOLD);
+            });
+        }
+
+		// Remove system tables
+		$tables_to_exclude = array('_mysql_data_types_cache');
+		$tables = array_diff($tables, $tables_to_exclude);
+
+        if (empty($tables)) {
+            if ($pattern) {
+                WP_CLI::error("No tables found matching: " . $pattern);
+            } else {
+                WP_CLI::error("No tables found in the database.");
+            }
+        }
+
+		$format = \WP_CLI\Utils\get_flag_value( $assoc_args, 'format' );
+
+		if ( 'csv' === $format ) {
+			WP_CLI::line( implode( ',', $tables ) );
+		} else {
+			foreach ( $tables as $table ) {
+				WP_CLI::line( $table );
+			}
+		}
+    }
+}

--- a/src/Tables.php
+++ b/src/Tables.php
@@ -9,7 +9,6 @@ use WP_SQLite_Translator;
 class Tables extends Base {
 
 	protected $translator;
-	protected $args      = array();
 
 	public function __construct() {
 		$this->load_dependencies();

--- a/src/Tables.php
+++ b/src/Tables.php
@@ -33,37 +33,22 @@ class Tables extends Base {
 	/**
 	 * Lists all tables in the SQLite database.
 	 *
-	 * @param array|null $patterns Optional wildcard patterns to filter tables.
 	 * @param array $assoc_args Associative array of options.
 	 * @return void
 	 */
-	public function run( ?array $patterns = null, $assoc_args = [] ) {
+	public function run( $assoc_args = [] ) {
 		$pdo = $this->get_pdo();
 
 		// Get all tables
 		$stmt   = $pdo->query( "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'" );
 		$tables = $stmt->fetchAll( PDO::FETCH_COLUMN );
 
-		// Filter tables if wildcard pattern is provided
-		if ( ! empty( $patterns ) ) {
-			foreach ( $patterns as $pattern ) {
-				$tables = array_filter(
-					$tables,
-					fn ( $table ) => fnmatch( $pattern, $table, FNM_CASEFOLD )
-				);
-			}
-		}
-
 		// Remove system tables
 		$tables_to_exclude = array( '_mysql_data_types_cache' );
 		$tables            = array_diff( $tables, $tables_to_exclude );
 
 		if ( empty( $tables ) ) {
-			if ( ! empty( $patterns ) ) {
-				WP_CLI::error( 'No tables found.' );
-			} else {
-				WP_CLI::error( 'No tables found in the database.' );
-			}
+			WP_CLI::error( 'No tables found in the database.' );
 		}
 
 		$format = \WP_CLI\Utils\get_flag_value( $assoc_args, 'format' );

--- a/src/Tables.php
+++ b/src/Tables.php
@@ -30,41 +30,44 @@ class Tables extends Base {
 		return $this->translator->get_pdo();
 	}
 
-    /**
-     * Lists all tables in the SQLite database.
-     *
-     * @param string|null $pattern Optional wildcard pattern to filter tables.
-     * @param array $assoc_args Associative array of options.
-     * @return void
-     */
-    public function run($pattern = null, $assoc_args = []) {
-        $pdo = $this->get_pdo();
+	/**
+	 * Lists all tables in the SQLite database.
+	 *
+	 * @param string|null $pattern Optional wildcard pattern to filter tables.
+	 * @param array $assoc_args Associative array of options.
+	 * @return void
+	 */
+	public function run( $pattern = null, $assoc_args = [] ) {
+		$pdo = $this->get_pdo();
 
-        // Get all tables
-        $stmt = $pdo->query("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'");
-        $tables = $stmt->fetchAll(PDO::FETCH_COLUMN);
+		// Get all tables
+		$stmt   = $pdo->query( "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'" );
+		$tables = $stmt->fetchAll( PDO::FETCH_COLUMN );
 
-        // Filter tables if wildcard pattern is provided
-        if ($pattern) {
-            $sql_pattern = str_replace('?', '_', $pattern);
-            $sql_pattern = str_replace('*', '%', $sql_pattern);
+		// Filter tables if wildcard pattern is provided
+		if ( $pattern ) {
+			$sql_pattern = str_replace( '?', '_', $pattern );
+			$sql_pattern = str_replace( '*', '%', $sql_pattern );
 
-            $tables = array_filter($tables, function($table) use ($pattern) {
-                return fnmatch($pattern, $table, FNM_CASEFOLD);
-            });
-        }
+			$tables = array_filter(
+				$tables,
+				function ( $table ) use ( $pattern ) {
+					return fnmatch( $pattern, $table, FNM_CASEFOLD );
+				}
+			);
+		}
 
 		// Remove system tables
-		$tables_to_exclude = array('_mysql_data_types_cache');
-		$tables = array_diff($tables, $tables_to_exclude);
+		$tables_to_exclude = array( '_mysql_data_types_cache' );
+		$tables            = array_diff( $tables, $tables_to_exclude );
 
-        if (empty($tables)) {
-            if ($pattern) {
-                WP_CLI::error("No tables found matching: " . $pattern);
-            } else {
-                WP_CLI::error("No tables found in the database.");
-            }
-        }
+		if ( empty( $tables ) ) {
+			if ( $pattern ) {
+				WP_CLI::error( 'No tables found matching: ' . $pattern );
+			} else {
+				WP_CLI::error( 'No tables found in the database.' );
+			}
+		}
 
 		$format = \WP_CLI\Utils\get_flag_value( $assoc_args, 'format' );
 
@@ -75,5 +78,5 @@ class Tables extends Base {
 				WP_CLI::line( $table );
 			}
 		}
-    }
+	}
 }


### PR DESCRIPTION
- Related to https://github.com/Automattic/dotcom-forge/issues/9932

## Description

- It adds a new command to get all the tables from the SQLite database
- It returns the results in two formats: `list` and `csv`

Examples

> wp sqlite tables --require=path/to/wp-cli-sqlite-command/command.php      
```
wp_users
wp_usermeta
wp_termmeta
wp_terms
wp_term_taxonomy
wp_term_relationships
wp_commentmeta
wp_comments
wp_links
wp_options
wp_postmeta
wp_posts
```

> wp sqlite tables --format=csv --require=/path/to/wp-cli-sqlite-command/command.php 
```
wp_users,wp_usermeta,wp_termmeta,wp_terms,wp_term_taxonomy,wp_term_relationships,wp_commentmeta,wp_comments,wp_links,wp_options,wp_postmeta,wp_posts
```

## Testing instructions

1. Run `composer install --no-dev` in this repo
2. Open your terminal and `cd` into the root directory of a Studio site
3. Copy the local path to this repository to use it in the next command:
4. Run `wp sqlite tables --format=csv --require=/path/to/wp-cli-sqlite-command/command.php `
5. Run `wp sqlite tables --require=/path/to/wp-cli-sqlite-command/command.php `
