### PR TITLE
Added tests for tables command and testing docs

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -6,8 +6,6 @@ on:
     branches:
       - main
       - master
-  schedule:
-    - cron: "17 1 * * *" # Run every day on a seemly random time.
 
 jobs:
   test:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - master
 
 jobs:
   test:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - master
 
 jobs:
   test:

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,13 @@
+# Testing
+
+This repo uses the [BDD](https://en.wikipedia.org/wiki/Behavior-driven_development) testing framework [Behat](https://docs.behat.org/en/latest/). It means we use plain text files to describe "scenarios" containing keywords like "given", "when", and "then". This methodology was [chosen](https://github.com/Automattic/wp-cli-sqlite-command/issues/3) because it's what WP CLI itself uses to [test commands](https://github.com/wp-cli/wp-cli-tests).
+
+The test cases are located in `features/*.feature`.
+
+## Running tests locally
+
+The test cases depend on real WordPress installations, meaning the usual PHP and MySQL dependencies are required. However, we can opt to use SQLite instead of MySQL to make running the tests locally easier. Here's how to run the full test suite with a SQLite database:
+
+```
+WP_CLI_TEST_DBTYPE=sqlite vendor/bin/behat
+```

--- a/features/sqlite_tables.feature
+++ b/features/sqlite_tables.feature
@@ -23,6 +23,7 @@ Feature: WP-CLI SQLite Tables Command
       wp_options
       wp_postmeta
       wp_posts
+      hello
       """
 
   @require-sqlite

--- a/features/sqlite_tables.feature
+++ b/features/sqlite_tables.feature
@@ -23,7 +23,6 @@ Feature: WP-CLI SQLite Tables Command
       wp_options
       wp_postmeta
       wp_posts
-      hello
       """
 
   @require-sqlite

--- a/features/sqlite_tables.feature
+++ b/features/sqlite_tables.feature
@@ -1,0 +1,34 @@
+Feature: WP-CLI SQLite Tables Command
+  In order to export individual tables from a WordPress SQLite table
+  As a website administrator
+  I need to be able to list the tables contained in the database
+
+  Background:
+    Given a WP installation
+
+  @require-sqlite
+  Scenario: Successfully list the tables in the SQLite database
+    When I run `wp sqlite tables`
+    Then STDOUT should contain:
+      """
+      wp_users
+      wp_usermeta
+      wp_termmeta
+      wp_terms
+      wp_term_taxonomy
+      wp_term_relationships
+      wp_commentmeta
+      wp_comments
+      wp_links
+      wp_options
+      wp_postmeta
+      wp_posts
+      """
+
+  @require-sqlite
+  Scenario: Successfully list the tables in the SQLite database in a CSV format
+    When I run `wp sqlite tables --format=csv`
+    Then STDOUT should contain:
+      """
+      wp_users,wp_usermeta,wp_termmeta,wp_terms,wp_term_taxonomy,wp_term_relationships,wp_commentmeta,wp_comments,wp_links,wp_options,wp_postmeta,wp_posts
+      """


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/9976

Following up from https://github.com/Automattic/wp-cli-sqlite-command/pull/5, this PR adds two Behat tests for the `wp sqlite tables` command.

Because I wasn't previously familiar with Behat, I also took the opportunity to add some rudimentary docs. 