### PR TITLE
Explicitly load the `sqlite-database-integration/php-polyfills.php` file

### DIFF
--- a/src/Base.php
+++ b/src/Base.php
@@ -83,6 +83,7 @@ class Base {
 		}
 
 		// We also need to selectively load the necessary classes from the plugin.
+		require_once $plugin_directory . '/php-polyfills.php';
 		require_once $plugin_directory . '/constants.php';
 		require_once $plugin_directory . '/wp-includes/sqlite/class-wp-sqlite-lexer.php';
 		require_once $plugin_directory . '/wp-includes/sqlite/class-wp-sqlite-query-rewriter.php';

--- a/src/Export.php
+++ b/src/Export.php
@@ -6,14 +6,14 @@ use PDO;
 use WP_CLI;
 use WP_SQLite_Translator;
 
-class Export extends Base {
+class Export {
 
 	protected $translator;
 	protected $args      = array();
 	protected $is_stdout = false;
 
 	public function __construct() {
-		$this->load_dependencies();
+		SQLiteDatabaseIntegrationLoader::load_plugin();
 		$this->translator = new WP_SQLite_Translator();
 	}
 

--- a/src/Import.php
+++ b/src/Import.php
@@ -6,13 +6,13 @@ use Generator;
 use WP_CLI;
 use WP_SQLite_Translator;
 
-class Import extends Base {
+class Import {
 
 	protected $translator;
 	protected $args;
 
 	public function __construct() {
-		$this->load_dependencies();
+		SQLiteDatabaseIntegrationLoader::load_plugin();
 		$this->translator = new WP_SQLite_Translator();
 	}
 

--- a/src/SQLiteDatabaseIntegrationLoader.php
+++ b/src/SQLiteDatabaseIntegrationLoader.php
@@ -3,7 +3,7 @@ namespace Automattic\WP_CLI\SQLite;
 
 use WP_CLI;
 
-class Base {
+final class SQLiteDatabaseIntegrationLoader {
 
 	/**
 	 * Get the version of the SQLite integration plugin if it is installed
@@ -11,7 +11,7 @@ class Base {
 	 *
 	 * @return false|string The version of the SQLite integration plugin or false if not found/activated.
 	 */
-	public static function get_sqlite_plugin_version() {
+	public static function get_plugin_version() {
 		// Check if there is a db.php file in the wp-content directory.
 		if ( ! file_exists( ABSPATH . '/wp-content/db.php' ) ) {
 			return false;
@@ -62,13 +62,13 @@ class Base {
 	 * @return void
 	 * @throws WP_CLI\ExitException
 	 */
-	protected function load_dependencies() {
+	public static function load_plugin() {
 		$plugin_directory = self::get_plugin_directory();
 		if ( ! $plugin_directory ) {
 			WP_CLI::error( 'Could not locate the SQLite integration plugin.' );
 		}
 
-		$sqlite_plugin_version = self::get_sqlite_plugin_version();
+		$sqlite_plugin_version = self::get_plugin_version();
 		if ( ! $sqlite_plugin_version ) {
 			WP_CLI::error( 'Could not determine the version of the SQLite integration plugin.' );
 		}

--- a/src/SQLite_Command.php
+++ b/src/SQLite_Command.php
@@ -79,6 +79,10 @@ class SQLite_Command extends WP_CLI_Command {
 	 * @when before_wp_load
 	 */
 	public function export( $args, $assoc_args ) {
+		if ( ! Export::get_sqlite_plugin_version() ) {
+			WP_CLI::error( 'The SQLite integration plugin is not installed or activated.' );
+		}
+
 		$is_porcelain = isset( $assoc_args['porcelain'] );
 
 		if ( ! $is_porcelain ) {
@@ -135,7 +139,7 @@ class SQLite_Command extends WP_CLI_Command {
 	 * @when before_wp_load
 	 */
 	public function tables( $args, $assoc_args ) {
-		if ( ! Base::get_sqlite_plugin_version() ) {
+		if ( ! Tables::get_sqlite_plugin_version() ) {
 			WP_CLI::error( 'The SQLite integration plugin is not installed or activated.' );
 		}
 

--- a/src/SQLite_Command.php
+++ b/src/SQLite_Command.php
@@ -29,10 +29,6 @@ class SQLite_Command extends WP_CLI_Command {
 			WP_CLI::error( 'Please provide a file to import.' );
 		}
 
-		if ( ! Import::get_sqlite_plugin_version() ) {
-			WP_CLI::error( 'The SQLite integration plugin is not installed or activated.' );
-		}
-
 		$import = new Import();
 		$import->run( $args[0], $assoc_args );
 	}
@@ -79,10 +75,6 @@ class SQLite_Command extends WP_CLI_Command {
 	 * @when before_wp_load
 	 */
 	public function export( $args, $assoc_args ) {
-		if ( ! Export::get_sqlite_plugin_version() ) {
-			WP_CLI::error( 'The SQLite integration plugin is not installed or activated.' );
-		}
-
 		$is_porcelain = isset( $assoc_args['porcelain'] );
 
 		if ( ! $is_porcelain ) {
@@ -139,10 +131,6 @@ class SQLite_Command extends WP_CLI_Command {
 	 * @when before_wp_load
 	 */
 	public function tables( $args, $assoc_args ) {
-		if ( ! Tables::get_sqlite_plugin_version() ) {
-			WP_CLI::error( 'The SQLite integration plugin is not installed or activated.' );
-		}
-
 		$tables = new Tables();
 		$tables->run( $assoc_args );
 	}

--- a/src/Tables.php
+++ b/src/Tables.php
@@ -6,12 +6,12 @@ use WP_CLI;
 use PDO;
 use WP_SQLite_Translator;
 
-class Tables extends Base {
+class Tables {
 
 	protected $translator;
 
 	public function __construct() {
-		$this->load_dependencies();
+		SQLiteDatabaseIntegrationLoader::load_plugin();
 		$this->translator = new WP_SQLite_Translator();
 	}
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/10054

In https://github.com/Automattic/dotcom-forge/issues/10054, we discovered that exports are currently broken in Studio when running PHP <8. This happens because `str_ends_with` is used in the `sqlite-database-integration` codebase, but that function only became part of PHP's stdlib in version 8. The crux is that `sqlite-database-integration` actually has a polyfill for this function, but that polyfill isn't loaded. This happens because we use the `before_wp_load` hook for the WP-CLI commands in this project, short-circuiting WP's regular logic for loading mu-plugins. Instead, we manually require files from `sqlite-database-integration`, but we hadn't previously included `php-polyfills.php`. This PR fixes that.

## Testing instructions

1. Clone this PR locally
2. Run `composer install --no-dev --optimize-autoloader --ignore-platform-reqs` in this repo
3. Replace `wp-files/sqlite-command` in the Studio repo with a symlink to your local `wp-cli-sqlite-command` repo
4. Apply 3658f-pb to the Studio repo
5. Run `npm start`
6. In the Settings tab, change the PHP version to 7.4
7. In the Import/Export tab, click "Export database"
8. Ensure a SQL dump is created successfully