### PR TITLE
Add a fallback for missing `DB_NAME` constant

### DIFF
--- a/src/SQLiteDriverFactory.php
+++ b/src/SQLiteDriverFactory.php
@@ -21,7 +21,12 @@ class SQLiteDriverFactory {
 					'path' => FQDB,
 				)
 			);
-			return new WP_SQLite_Driver( $connection, DB_NAME );
+			if ( defined( 'DB_NAME' ) && '' !== DB_NAME ) {
+				$db_name = DB_NAME;
+			} else {
+				$db_name = 'database_name_here';
+			}
+			return new WP_SQLite_Driver( $connection, $db_name );
 		}
 
 		return new WP_SQLite_Translator();


### PR DESCRIPTION
When the `DB_NAME` constant is not defined in `wp-config.php`, using the new SQLite driver with the CLI commands would fail with the following error:

```
[2025-08-06T07:09:58.483Z][warn][wp-cli-process] PHP.run() output was: #!/usr/bin/env php
<br />
<b>Fatal error</b>:  Uncaught Error: Undefined constant &quot;Automattic\WP_CLI\SQLite\DB_NAME&quot; in /tmp/sqlite-command/src/SQLiteDriverFactory.php:24
Stack trace:
#0 /tmp/sqlite-command/src/Import.php(21): Automattic\WP_CLI\SQLite\SQLiteDriverFactory::create_driver()
#1 /tmp/sqlite-command/src/SQLite_Command.php(44): Automattic\WP_CLI\SQLite\Import-&gt;__construct()
#2 [internal function]: Automattic\WP_CLI\SQLite\SQLite_Command-&gt;import(Array, Array)
#3 /tmp/sqlite-command/vendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/CommandFactory.php(100): call_user_func(Array, Array, Array)
#4 [internal function]: WP_CLI\Dispatcher\CommandFactory::WP_CLI\Dispatcher\{closure}(Array, Array)
#5 /tmp/sqlite-command/vendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/Subcommand.php(497): call_user_func(Object(Closure), Array, Array)
#6 phar:///tmp/wp-cli.phar/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(470): WP_CLI\Dispatcher\Subcommand-&gt;invoke(Array, Array, Array)
#7 phar:///tmp/wp-cli.phar/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(493): WP_CLI\Runner-&gt;run_command(Array, Array)
#8 phar:///tmp/wp-cli.phar/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(136): WP_CLI\Runner-&gt;run_command_and_exit()
#9 phar:///tmp/wp-cli.phar/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(1349): WP_CLI\Runner-&gt;do_early_invoke('after_wp_config...')
#10 phar:///tmp/wp-cli.phar/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(1293): WP_CLI\Runner-&gt;load_wordpress()
#11 phar:///tmp/wp-cli.phar/vendor/wp-cli/wp-cli/php/WP_CLI/Bootstrap/LaunchRunner.php(28): WP_CLI\Runner-&gt;start()
#12 phar:///tmp/wp-cli.phar/vendor/wp-cli/wp-cli/php/bootstrap.php(84): WP_CLI\Bootstrap\LaunchRunner-&gt;process(Object(WP_CLI\Bootstrap\BootstrapState))
#13 phar:///tmp/wp-cli.phar/vendor/wp-cli/wp-cli/php/wp-cli.php(35): WP_CLI\bootstrap()
#14 phar:///tmp/wp-cli.phar/php/boot-phar.php(20): include('phar:///tmp/wp-...')
#15 /tmp/wp-cli.phar(4): include('phar:///tmp/wp-...')
#16 /tmp/run-cli.php(37): require('/tmp/wp-cli.pha...')
#17 {main}
  thrown in <b>/tmp/sqlite-command/src/SQLiteDriverFactory.php</b> on line <b>24</b><br />
```

This fix ensures a database name is provided, using [the same fallback that Studio relies on](https://github.com/Automattic/studio/blob/5cf4f51a22dad9672a5124a38a2d60a747bf7eef/vendor/wp-now/src/wp-now.ts#L539).