### PR TITLE
Fix sqlite export by escaping strings with numbers and e character

### DIFF
--- a/features/bootstrap/SQLiteFeatureContext.php
+++ b/features/bootstrap/SQLiteFeatureContext.php
@@ -166,4 +166,27 @@ class SQLiteFeatureContext extends WPCLIFeatureContext implements Context {
 			throw new Exception( "File contains unexpected content:\n" . $content );
 		}
 	}
+
+	/**
+	 * @Given /^the SQLite database contains a test table with alphanumeric string hash values$/
+	 */
+	public function theSqliteDatabaseContainsATestTableWithAlphanumericStringHashValues() {
+		$this->connectToDatabase();
+
+		// Create a test table with hash values that look like scientific notation
+		$this->db->exec("DROP TABLE IF EXISTS test_export_alphanumeric_string");
+		$this->db->exec("
+			CREATE TABLE test_export_alphanumeric_string (
+				id INTEGER PRIMARY KEY,
+				hash_value TEXT
+			)
+		");
+
+		// Insert test data with values that might be mistaken for scientific notation
+		$this->db->exec("
+			INSERT INTO test_export_alphanumeric_string (id, hash_value) VALUES
+			(1, '123e99')
+		");
+	}
+
 }

--- a/features/bootstrap/SQLiteFeatureContext.php
+++ b/features/bootstrap/SQLiteFeatureContext.php
@@ -174,19 +174,22 @@ class SQLiteFeatureContext extends WPCLIFeatureContext implements Context {
 		$this->connectToDatabase();
 
 		// Create a test table with hash values that look like scientific notation
-		$this->db->exec("DROP TABLE IF EXISTS test_export_alphanumeric_string");
-		$this->db->exec("
+		$this->db->exec( 'DROP TABLE IF EXISTS test_export_alphanumeric_string' );
+		$this->db->exec(
+			'
 			CREATE TABLE test_export_alphanumeric_string (
 				id INTEGER PRIMARY KEY,
 				hash_value TEXT
 			)
-		");
+		'
+		);
 
 		// Insert test data with values that might be mistaken for scientific notation
-		$this->db->exec("
+		$this->db->exec(
+			"
 			INSERT INTO test_export_alphanumeric_string (id, hash_value) VALUES
 			(1, '123e99')
-		");
+		"
+		);
 	}
-
 }

--- a/features/sqlite-export.feature
+++ b/features/sqlite-export.feature
@@ -115,3 +115,21 @@ Feature: WP-CLI SQLite Export Command
       """
       CREATE TABLE `wp_users`
       """
+
+  @require-sqlite
+  Scenario: Export should escape alphanumeric strings with e character
+    Given the SQLite database contains a test table with alphanumeric string hash values
+    When I run `wp sqlite export test_export_alphanumeric_string.sql --tables=test_export_alphanumeric_string`
+    Then STDOUT should contain:
+      """
+      Success: Export complete. File written to test_export_alphanumeric_string.sql
+      """
+    And the file "test_export_alphanumeric_string.sql" should exist
+    And the file "test_export_alphanumeric_string.sql" should contain:
+      """
+      INSERT INTO `test_export_alphanumeric_string` VALUES (1,'123e99');
+      """
+    But the file "test_export_alphanumeric_string.sql" should not contain:
+      """
+      INSERT INTO `test_export_alphanumeric_string` VALUES (1,123e99);
+      """

--- a/src/Export.php
+++ b/src/Export.php
@@ -239,7 +239,7 @@ class Export {
 		foreach ( $values as $value ) {
 			if ( is_null( $value ) ) {
 				$escaped_values[] = 'NULL';
-			} elseif ( is_numeric( $value ) ) {
+			} elseif ( ctype_digit( $value ) ) {
 				$escaped_values[] = $value;
 			} else {
 				// Quote the values and escape encode the newlines so the insert statement appears on a single line.


### PR DESCRIPTION
Related to pfHvTO-C8-p2#comment-596

Change is_numeric comparison in favor of ctype_digit to avoid confusion with alphanumeric strings with e character like 123e99. This will prevent the issue when exporting mailpoet table.

```
is_numeric( '123e99' ) -> True
ctype_digit( '123e99' ) -> False
```
## Testing Instructions

**Test with Studio:**

* Checkout Studio repo https://github.com/Automattic/studio
* Apply this diff
```diff
diff --git a/src/setup-wp-server-files.ts b/src/setup-wp-server-files.ts
index 611d4fd0..751f8e91 100644
--- a/src/setup-wp-server-files.ts
+++ b/src/setup-wp-server-files.ts
@@ -91,7 +91,7 @@ async function copyBundledWPCLI() {
 
 async function copyBundledSQLiteCommand() {
 	const bundledSqliteCommandPath = path.join( getResourcesPath(), 'wp-files', 'sqlite-command' );
-	const bundledSqliteCommandVersion = await getSQLiteCommandVersion( bundledSqliteCommandPath );
+	const bundledSqliteCommandVersion = 'v1.1.2';
 	if ( ! bundledSqliteCommandVersion ) {
 		return;
 	}
@@ -120,6 +120,4 @@ export async function updateWPServerFiles() {
 	await updateLatestSqliteVersion();
 	const provider = new WpNowProvider();
 	await provider.updateLatestWPCliVersion();
-
-	await updateLatestSQLiteCommandVersion();
 }
```
* Run `npm install`
* Delete the folder `studio/wp-files/sqlite-command`
* Delete also the folder `~/Library/Application\ Support/Studio/server-files/sqlite-command`
* Checkout this repository and this branch
* Run `composer install --no-dev --optimize-autoloader --ignore-platform-reqs`
* Create a symbolic link from wp-cli-sqlite-command to studio/wp-files/sqlite-command.
* Run npm start in studio folder
* Create a site
* Go to import tab
* Drop this sql file

[wp_mailpoet_newsletter_links.sql](https://github.com/user-attachments/files/22157201/wp_mailpoet_newsletter_links.sql)

* Click on export database
* Observe the produced SQL dump has the escaped value `'123e99'`.

**Before**

<img width="2280" height="236" alt="Screenshot 2025-09-04 at 20 21 58" src="https://github.com/user-attachments/assets/cd124a60-5d3f-486c-abda-3508d8b227a4" />


**After**

<img width="2282" height="212" alt="Screenshot 2025-09-04 at 20 22 37" src="https://github.com/user-attachments/assets/c9f7bff1-72ec-46e9-b517-f13ce5db82ba" />