### PR TITLE
Remove custom parser in favor of AST parser

### DIFF
--- a/src/Import.php
+++ b/src/Import.php
@@ -139,13 +139,13 @@ class Import {
 	}
 
 	/**
-		 * Execute SQL statements from an SQL dump file using the AST parser.
-		 *
-		 * @param $import_file
-		 *
-		 * @return void
-		 * @throws Exception
-		 */
+	 * Execute SQL statements from an SQL dump file using the AST parser.
+	 *
+	 * @param $import_file
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
 	protected function execute_statements_with_ast_parser( $import_file ) {
 		$raw_queries = file_get_contents( $import_file );
 		$parser      = $this->driver->create_parser( $raw_queries );

--- a/src/Import.php
+++ b/src/Import.php
@@ -164,7 +164,7 @@ class Import {
 			} catch ( Exception $e ) {
 				// Skip errors when executing SET comment statements
 				if ( 0 === strpos( $statement, 'SET ' ) && false !== strpos( $statement, '*/' ) ) {
-					WP_CLI::warning( 'SQLite import SET comment statement: ' . $statement );
+					echo 'Warning - SQLite import skipped SET comment statement: ' . $statement . PHP_EOL;
 					continue;
 				}
 				WP_CLI::error( 'SQLite import could not execute statement: ' . $statement );

--- a/src/Import.php
+++ b/src/Import.php
@@ -45,8 +45,14 @@ class Import {
 		WP_CLI::success( sprintf( "Imported from '%s'.", $imported_from ) );
 	}
 
-
-
+	/**
+	 * Execute SQL statements from an SQL dump file.
+	 *
+	 * @param $import_file
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
 	protected function execute_statements( $import_file ) {
 		foreach ( $this->parse_statements( $import_file ) as $statement ) {
 			$result = $this->driver->query( $statement );
@@ -133,7 +139,7 @@ class Import {
 	}
 
 	/**
-	 * Execute SQL statements from an SQL dump file.
+	 * Execute SQL statements from an SQL dump file using the AST parser.
 	 *
 	 * @param $import_file
 	 *

--- a/src/Import.php
+++ b/src/Import.php
@@ -35,10 +35,101 @@ class Import {
 		$is_stdin    = '-' === $sql_file_path;
 		$import_file = $is_stdin ? 'php://stdin' : $sql_file_path;
 
-		$this->execute_statements( $import_file );
+		if ( method_exists( $this->driver, 'create_parser' ) ) {
+			$this->execute_statements_with_ast_parser( $import_file );
+		} else {
+			$this->execute_statements( $import_file );
+		}
 
 		$imported_from = $is_stdin ? 'STDIN' : $sql_file_path;
 		WP_CLI::success( sprintf( "Imported from '%s'.", $imported_from ) );
+	}
+
+
+
+	protected function execute_statements( $import_file ) {
+		foreach ( $this->parse_statements( $import_file ) as $statement ) {
+			$result = $this->driver->query( $statement );
+			if ( false === $result ) {
+				WP_CLI::warning( 'Could not execute statement: ' . $statement );
+				echo $this->driver->get_error_message();
+			}
+		}
+	}
+
+	/**
+	 * Parse SQL statements from an SQL dump file.
+	 * @param string $sql_file_path The path to the SQL dump file.
+	 *
+	 * @return Generator A generator that yields SQL statements.
+	 */
+	public function parse_statements( $sql_file_path ) {
+
+		$handle = fopen( $sql_file_path, 'r' );
+
+		if ( ! $handle ) {
+			WP_CLI::error( "Unable to open file: $sql_file_path" );
+		}
+
+		$single_quotes = 0;
+		$double_quotes = 0;
+		$in_comment    = false;
+		$buffer        = '';
+
+		// phpcs:ignore
+		while ( ( $line = fgets( $handle ) ) !== false ) {
+			$line = trim( $line );
+
+			// Skip empty lines and comments
+			if ( empty( $line ) || strpos( $line, '--' ) === 0 || strpos( $line, '#' ) === 0 ) {
+				continue;
+			}
+
+			// Handle multi-line comments
+			if ( ! $in_comment && strpos( $line, '/*' ) === 0 ) {
+				$in_comment = true;
+			}
+			if ( $in_comment ) {
+				if ( strpos( $line, '*/' ) !== false ) {
+					$in_comment = false;
+				}
+				continue;
+			}
+
+			$strlen = strlen( $line );
+			for ( $i = 0; $i < $strlen; $i++ ) {
+				$ch = $line[ $i ];
+
+				// Handle escaped characters
+				if ( $i > 0 && '\\' === $line[ $i - 1 ] ) {
+					$buffer .= $ch;
+					continue;
+				}
+
+				// Handle quotes
+				if ( "'" === $ch && 0 === $double_quotes ) {
+					$single_quotes = 1 - $single_quotes;
+				}
+				if ( '"' === $ch && 0 === $single_quotes ) {
+					$double_quotes = 1 - $double_quotes;
+				}
+
+				// Process statement end
+				if ( ';' === $ch && 0 === $single_quotes && 0 === $double_quotes ) {
+					yield trim( $buffer );
+					$buffer = '';
+				} else {
+					$buffer .= $ch;
+				}
+			}
+		}
+
+		// Handle any remaining buffer content
+		if ( ! empty( $buffer ) ) {
+			yield trim( $buffer );
+		}
+
+		fclose( $handle );
 	}
 
 	/**
@@ -49,7 +140,7 @@ class Import {
 	 * @return void
 	 * @throws Exception
 	 */
-	protected function execute_statements( $import_file ) {
+	protected function execute_statements_with_ast_parser( $import_file ) {
 		$raw_queries  = file_get_contents( $import_file );
 		$queries_text = $this->remove_comments( $raw_queries );
 		$parser       = $this->driver->create_parser( $queries_text );

--- a/src/Import.php
+++ b/src/Import.php
@@ -73,6 +73,6 @@ class Import {
 	 * @return string
 	 */
 	protected function remove_comments( $text ) {
-		return preg_replace( '/\/\*.*?\*\//s', '', $text );
+		return preg_replace( '/\/\*.*?\*\/(;)?/s', '', $text );
 	}
 }

--- a/src/Import.php
+++ b/src/Import.php
@@ -50,8 +50,13 @@ class Import {
 	 * @throws Exception
 	 */
 	protected function execute_statements( $import_file ) {
-		foreach ( $this->parse_statements( $import_file ) as $statement ) {
-			$result = $this->driver->query( $statement );
+		$raw_queries  = file_get_contents( $import_file );
+		$queries_text = $this->remove_comments( $raw_queries );
+		$parser       = $this->driver->create_parser( $queries_text );
+		while ( $parser->next_query() ) {
+			$ast       = $parser->get_query_ast();
+			$statement = substr( $queries_text, $ast->get_start(), $ast->get_length() );
+			$result    = $this->driver->query( $statement );
 			if ( false === $result ) {
 				WP_CLI::warning( 'Could not execute statement: ' . $statement );
 				echo $this->driver->get_error_message();
@@ -60,77 +65,13 @@ class Import {
 	}
 
 	/**
-	 * Parse SQL statements from an SQL dump file.
-	 * @param string $sql_file_path The path to the SQL dump file.
+	 * Remove comments from the input.
 	 *
-	 * @return Generator A generator that yields SQL statements.
+	 * @param string $input
+	 *
+	 * @return string
 	 */
-	public function parse_statements( $sql_file_path ) {
-
-		$handle = fopen( $sql_file_path, 'r' );
-
-		if ( ! $handle ) {
-			WP_CLI::error( "Unable to open file: $sql_file_path" );
-		}
-
-		$single_quotes = 0;
-		$double_quotes = 0;
-		$in_comment    = false;
-		$buffer        = '';
-
-		// phpcs:ignore
-		while ( ( $line = fgets( $handle ) ) !== false ) {
-			$line = trim( $line );
-
-			// Skip empty lines and comments
-			if ( empty( $line ) || strpos( $line, '--' ) === 0 || strpos( $line, '#' ) === 0 ) {
-				continue;
-			}
-
-			// Handle multi-line comments
-			if ( ! $in_comment && strpos( $line, '/*' ) === 0 ) {
-				$in_comment = true;
-			}
-			if ( $in_comment ) {
-				if ( strpos( $line, '*/' ) !== false ) {
-					$in_comment = false;
-				}
-				continue;
-			}
-
-			$strlen = strlen( $line );
-			for ( $i = 0; $i < $strlen; $i++ ) {
-				$ch = $line[ $i ];
-
-				// Handle escaped characters
-				if ( $i > 0 && '\\' === $line[ $i - 1 ] ) {
-					$buffer .= $ch;
-					continue;
-				}
-
-				// Handle quotes
-				if ( "'" === $ch && 0 === $double_quotes ) {
-					$single_quotes = 1 - $single_quotes;
-				}
-				if ( '"' === $ch && 0 === $single_quotes ) {
-					$double_quotes = 1 - $double_quotes;
-				}
-
-				// Process statement end
-				if ( ';' === $ch && 0 === $single_quotes && 0 === $double_quotes ) {
-					yield trim( $buffer );
-					$buffer = '';
-				} else {
-					$buffer .= $ch;
-				}
-			}
-		}
-
-		// Handle any remaining buffer content
-		if ( ! empty( $buffer ) ) {
-			yield trim( $buffer );
-		}
-
-		fclose( $handle );
+	protected function remove_comments( $text ) {
+		return preg_replace( '/\/\*.*?\*\//s', '', $text );
 	}
 }

--- a/src/Import.php
+++ b/src/Import.php
@@ -56,9 +56,10 @@ class Import {
 		while ( $parser->next_query() ) {
 			$ast       = $parser->get_query_ast();
 			$statement = substr( $queries_text, $ast->get_start(), $ast->get_length() );
-			$result    = $this->driver->query( $statement );
-			if ( false === $result ) {
-				WP_CLI::warning( 'Could not execute statement: ' . $statement );
+			try {
+				$this->driver->query( $statement );
+			} catch ( Exception $e ) {
+				WP_CLI::error( 'SQLite import could not execute statement: ' . $statement );
 				echo $this->driver->get_error_message();
 			}
 		}

--- a/src/Import.php
+++ b/src/Import.php
@@ -148,7 +148,14 @@ class Import {
 	 */
 	protected function execute_statements_with_ast_parser( $import_file ) {
 		$raw_queries = file_get_contents( $import_file );
-		$parser      = $this->driver->create_parser( $raw_queries );
+
+		// Detect and convert encoding to UTF-8
+		$detected_encoding = mb_detect_encoding( $raw_queries, mb_list_encodings(), true );
+		if ( $detected_encoding && 'UTF-8' !== $detected_encoding ) {
+			$raw_queries = mb_convert_encoding( $raw_queries, 'UTF-8', $detected_encoding );
+		}
+
+		$parser = $this->driver->create_parser( $raw_queries );
 		while ( $parser->next_query() ) {
 			$ast       = $parser->get_query_ast();
 			$statement = substr( $raw_queries, $ast->get_start(), $ast->get_length() );


### PR DESCRIPTION
Fixes:
- STU-844
- https://github.com/WordPress/sqlite-database-integration/issues/263
- https://github.com/WordPress/sqlite-database-integration/issues/250 

As suggested in https://github.com/WordPress/sqlite-database-integration/issues/263#issuecomment-3380284929 , we'll use the AST parser to split the queries from a SQL dump file. The only downside is that we are loading the whole dump into memory.



## Testing Instructions

* Create a blank site using Studio
* It doesn't matter if the site is running or not.
* Edit the file `~/Library/Application Support/Studio/server-files/sqlite-command/src/Import.php` with the changes from this PR.
* In Studio go to the Import/Export tab
* Try multiple queries like those provided on STU-844 or https://github.com/WordPress/sqlite-database-integration/issues/250, or [wp_redirection_404_with-create-table.sql](https://github.com/user-attachments/files/22771369/wp_redirection_404_with-create-table.sql)
* Confirm that the SQL files are imported correctly.
* Try importing the same SQL dump and confirm that an alert appears stating that "Create Table" couldn't be executed. This is expected because you already imported that dump and created the table.
* Feel free to try other sites and queries to confirm everything works as expected.
