### PR TITLE
Fix import query parsing

### DIFF
--- a/features/bootstrap/SQLiteFeatureContext.php
+++ b/features/bootstrap/SQLiteFeatureContext.php
@@ -38,7 +38,7 @@ class SQLiteFeatureContext extends WPCLIFeatureContext implements Context {
 	 */
 	public function theTableShouldContainARowWithName( $table_name, $name ) {
 		$this->connectToDatabase();
-		$result = $this->db->query( "SELECT * FROM $table_name WHERE name='$name'" );
+		$result = $this->db->query( "SELECT * FROM $table_name WHERE name='" . $this->db->escapeString( $name ) . "'" );
 		$row    = $result->fetchArray();
 		if ( ! $row ) {
 			throw new Exception( "Row with name '$name' not found in table '$table_name'." );

--- a/features/bootstrap/SQLiteFeatureContext.php
+++ b/features/bootstrap/SQLiteFeatureContext.php
@@ -25,7 +25,7 @@ class SQLiteFeatureContext extends WPCLIFeatureContext implements Context {
 	 */
 	public function theSqliteDatabaseShouldContainATableNamed( $table_name ) {
 		$this->connectToDatabase();
-		$result = $this->db->query( "SELECT name FROM sqlite_master WHERE type='table' AND name='$table_name'" );
+		$result = $this->db->query( "SELECT name FROM sqlite_master WHERE type='table' AND name='" . $this->db->escapeString( $table_name ) . "'" );
 		$row    = $result->fetchArray();
 		if ( ! $row ) {
 			throw new Exception( "Table '$table_name' not found in the database." );

--- a/features/bootstrap/SQLiteFeatureContext.php
+++ b/features/bootstrap/SQLiteFeatureContext.php
@@ -34,6 +34,7 @@ class SQLiteFeatureContext extends WPCLIFeatureContext implements Context {
 
 	/**
 	 * @Then /^the "([^"]*)" should contain a row with name "([^"]*)"$/
+	 * @Then /^the "([^"]*)" should contain a row with name:$/
 	 */
 	public function theTableShouldContainARowWithName( $table_name, $name ) {
 		$this->connectToDatabase();

--- a/features/sqlite-import.feature
+++ b/features/sqlite-import.feature
@@ -67,3 +67,23 @@ Feature: WP-CLI SQLite Import Command
     And the "test_table" should contain a row with name "Test that escaping a character \a works"
     And the "test_table" should contain a row with name "Test that escaping a backslash followed by a character \\a works"
     And the "test_table" should contain a row with name "Test that escaping a backslash and a character \\\a works"
+
+  @require-sqlite
+  Scenario: Import a file with newlines in strings
+    Given a SQL dump file named "test_import.sql" with content:
+      """
+      CREATE TABLE test_table (id INTEGER PRIMARY KEY AUTO_INCREMENT, name TEXT);
+      INSERT INTO test_table (name) VALUES ('Test that a string containing
+          a newline character and some whitespace works');
+      """
+    When I run `wp sqlite --enable-ast-driver import test_import.sql`
+    Then STDOUT should contain:
+      """
+      Success: Imported from 'test_import.sql'.
+      """
+    And the SQLite database should contain a table named "test_table"
+    And the "test_table" should contain a row with name:
+      """
+      Test that a string containing
+          a newline character and some whitespace works
+      """

--- a/features/sqlite-import.feature
+++ b/features/sqlite-import.feature
@@ -137,3 +137,17 @@ Feature: WP-CLI SQLite Import Command
       """
       a double-quoted string with ' some " " tricky ` chars
       """
+
+  @require-sqlite
+  Scenario: Import a file backtick-quoted identifiers
+    Given a SQL dump file named "test_import.sql" with content:
+      """
+      CREATE TABLE `a'strange``identifier\\name` (id INTEGER PRIMARY KEY AUTO_INCREMENT, name TEXT);
+      """
+    When I run `wp sqlite --enable-ast-driver import test_import.sql`
+    Then STDOUT should contain:
+      """
+      Success: Imported from 'test_import.sql'.
+      """
+
+    And the SQLite database should contain a table named "a'strange`identifier\name"

--- a/features/sqlite-import.feature
+++ b/features/sqlite-import.feature
@@ -114,3 +114,26 @@ Feature: WP-CLI SQLite Import Command
     And the "test_table" should contain a row with name "three"
     And the "test_table" should contain a row with name "fo -- this looks like a comment ur"
     And the "test_table" should contain a row with name "fi/* this looks like a comment */ve"
+
+  @require-sqlite
+  Scenario: Import a file quoted strings
+    Given a SQL dump file named "test_import.sql" with content:
+      """
+      CREATE TABLE test_table (id INTEGER PRIMARY KEY AUTO_INCREMENT, name TEXT);
+      INSERT INTO test_table (name) VALUES ('a single-quoted string with \' '' some " tricky ` chars');
+      INSERT INTO test_table (name) VALUES ("a double-quoted string with ' some \" "" tricky ` chars");
+      """
+    When I run `wp sqlite --enable-ast-driver import test_import.sql`
+    Then STDOUT should contain:
+      """
+      Success: Imported from 'test_import.sql'.
+      """
+    And the SQLite database should contain a table named "test_table"
+    And the "test_table" should contain a row with name:
+      """
+      a single-quoted string with ' ' some " tricky ` chars
+      """
+    And the "test_table" should contain a row with name:
+      """
+      a double-quoted string with ' some " " tricky ` chars
+      """

--- a/features/sqlite-import.feature
+++ b/features/sqlite-import.feature
@@ -151,3 +151,23 @@ Feature: WP-CLI SQLite Import Command
       """
 
     And the SQLite database should contain a table named "a'strange`identifier\name"
+
+  @require-sqlite
+  Scenario: Import a file with whitespace and empty lines
+    Given a SQL dump file named "test_import.sql" with content:
+      """
+
+      CREATE TABLE test_table (id INTEGER PRIMARY KEY AUTO_INCREMENT, name TEXT);
+
+
+      INSERT INTO test_table (name) VALUES ('Test Name');
+
+      """
+    When I run `wp sqlite --enable-ast-driver import test_import.sql`
+    Then STDOUT should contain:
+      """
+      Success: Imported from 'test_import.sql'.
+      """
+
+    And the SQLite database should contain a table named "test_table"
+    And the "test_table" should contain a row with name "Test Name"

--- a/src/Import.php
+++ b/src/Import.php
@@ -139,7 +139,10 @@ class Import {
 
 				// Process statement end
 				if ( ';' === $ch && null === $starting_quote ) {
-					yield trim( $buffer );
+					$buffer = trim( $buffer );
+					if ( ! empty( $buffer ) ) {
+						yield $buffer;
+					}
 					$buffer = '';
 				} else {
 					$buffer .= $ch;
@@ -148,8 +151,9 @@ class Import {
 		}
 
 		// Handle any remaining buffer content
+		$buffer = trim( $buffer );
 		if ( ! empty( $buffer ) ) {
-			yield trim( $buffer );
+			yield $buffer;
 		}
 
 		fclose( $handle );

--- a/src/Import.php
+++ b/src/Import.php
@@ -89,18 +89,22 @@ class Import {
 			for ( $i = 0; $i < $strlen; $i++ ) {
 				$ch = $line[ $i ];
 
-				// Count preceding backslashes.
-				$slashes = 0;
-				while ( $slashes < $i && '\\' === $line[ $i - $slashes - 1 ] ) {
-					++$slashes;
-				}
+				// Handle escape sequences in single and double quoted strings.
+				// TODO: Support NO_BACKSLASH_ESCAPES SQL mode.
+				if ( "'" === $ch || '"' === $ch ) {
+					// Count preceding backslashes.
+					$slashes = 0;
+					while ( $slashes < $i && '\\' === $line[ $i - $slashes - 1 ] ) {
+						++$slashes;
+					}
 
-				// Handle escaped characters.
-				// A characters is escaped only when the number of preceding backslashes
-				// is odd - "\" is an escape sequence, "\\" is an escaped backslash.
-				if ( 1 === $slashes % 2 ) {
-					$buffer .= $ch;
-					continue;
+					// Handle escaped characters.
+					// A characters is escaped only when the number of preceding backslashes
+					// is odd - "\" is an escape sequence, "\\" is an escaped backslash.
+					if ( 1 === $slashes % 2 ) {
+						$buffer .= $ch;
+						continue;
+					}
 				}
 
 				// Handle comments.

--- a/src/Import.php
+++ b/src/Import.php
@@ -86,8 +86,6 @@ class Import {
 				$line = mb_convert_encoding( $line, 'UTF-8', $detected_encoding );
 			}
 
-			$line = trim( $line );
-
 			// Skip empty lines and comments
 			if ( empty( $line ) || strpos( $line, '--' ) === 0 || strpos( $line, '#' ) === 0 ) {
 				continue;

--- a/src/Import.php
+++ b/src/Import.php
@@ -127,7 +127,7 @@ class Import {
 				}
 
 				// Handle quotes
-				if ( null === $starting_quote && ( "'" === $ch || '"' === $ch ) ) {
+				if ( null === $starting_quote && ( "'" === $ch || '"' === $ch || '`' === $ch ) ) {
 					$starting_quote = $ch;
 				} elseif ( null !== $starting_quote && $ch === $starting_quote ) {
 					$starting_quote = null;

--- a/src/Import.php
+++ b/src/Import.php
@@ -102,8 +102,16 @@ class Import {
 			for ( $i = 0; $i < $strlen; $i++ ) {
 				$ch = $line[ $i ];
 
-				// Handle escaped characters
-				if ( $i > 0 && '\\' === $line[ $i - 1 ] ) {
+				// Count preceding backslashes.
+				$slashes = 0;
+				while ( $slashes < $i && '\\' === $line[ $i - $slashes - 1 ] ) {
+					++$slashes;
+				}
+
+				// Handle escaped characters.
+				// A characters is escaped only when the number of preceding backslashes
+				// is odd - "\" is an escape sequence, "\\" is an escaped backslash.
+				if ( 1 === $slashes % 2 ) {
 					$buffer .= $ch;
 					continue;
 				}

--- a/src/Import.php
+++ b/src/Import.php
@@ -80,6 +80,12 @@ class Import {
 
 		// phpcs:ignore
 		while ( ( $line = fgets( $handle ) ) !== false ) {
+			// Detect and convert encoding to UTF-8
+			$detected_encoding = mb_detect_encoding( $line, mb_list_encodings(), true );
+			if ( $detected_encoding && 'UTF-8' !== $detected_encoding ) {
+				$line = mb_convert_encoding( $line, 'UTF-8', $detected_encoding );
+			}
+
 			$line = trim( $line );
 
 			// Skip empty lines and comments


### PR DESCRIPTION
### Description:
This is a quick fix of import query parsing, replacing https://github.com/Automattic/wp-cli-sqlite-command/pull/13 for now. It adds multiple fixes and improvements that make the query recognition in the input dump almost complete.

The only known edge cases that aren't supported yet are the usage of `NO_BACKSLASH_ESCAPES` SQL mode, and the MySQL `DELIMITER ...` statement. We likely won't implement those in the current logic—it's better to make the new query tokenizer fully support streaming to handle all edge cases correctly.

### Related issues:
- Fixes STU-844.
- Fixes https://github.com/WordPress/sqlite-database-integration/issues/263.
- Fixes https://github.com/WordPress/sqlite-database-integration/issues/250.

### Testing Instructions

* Create a blank site using Studio
* It doesn't matter if the site is running or not.
* Edit the file `~/Library/Application Support/Studio/server-files/sqlite-command/src/Import.php` with the changes from this PR.
* In Studio go to the Import/Export tab
* Try multiple queries like those provided on STU-844 or https://github.com/WordPress/sqlite-database-integration/issues/250, or [wp_redirection_404_with-create-table.sql](https://github.com/user-attachments/files/22771369/wp_redirection_404_with-create-table.sql)
* Confirm that the SQL files are imported correctly.
* Try importing the same SQL dump and confirm that an alert appears stating that "Create Table" couldn't be executed. This is expected because you already imported that dump and created the table.
* Feel free to try other sites and queries to confirm everything works as expected.
