### PR TITLE
Re throw the error when the encoding is correct but the import query failed

### DIFF
--- a/src/Import.php
+++ b/src/Import.php
@@ -66,7 +66,7 @@ class Import {
 						throw $e;
 					}
 				} catch ( Exception $e ) {
-					WP_CLI::warning( 'Could not execute statement: ' . $statement );
+					WP_CLI::error( 'Could not execute statement: ' . $statement );
 					echo $e->getMessage();
 				}
 			}

--- a/src/Import.php
+++ b/src/Import.php
@@ -62,7 +62,7 @@ class Import {
 						echo 'Converted ecoding for statement: ' . $converted_statement . PHP_EOL;
 						$this->driver->query( $converted_statement );
 					} else {
-						// It's not a encoding issue, so rethrow the exception.
+						// It's not an encoding issue, so rethrow the exception.
 						throw $e;
 					}
 				} catch ( Exception $e ) {

--- a/src/Import.php
+++ b/src/Import.php
@@ -61,6 +61,9 @@ class Import {
 						$converted_statement = mb_convert_encoding( $statement, 'UTF-8', $detected_encoding );
 						echo 'Converted ecoding for statement: ' . $converted_statement . PHP_EOL;
 						$this->driver->query( $converted_statement );
+					} else {
+						// It's not a encoding issue, so rethrow the exception.
+						throw $e;
 					}
 				} catch ( Exception $e ) {
 					WP_CLI::warning( 'Could not execute statement: ' . $statement );


### PR DESCRIPTION
- Fixes STU-871
- Related to https://github.com/Automattic/wp-cli-sqlite-command/pull/15

## Proposed changes

* Pass the error when a query is in UTF-8 format and fails to run the import.

## Testing steps

* Apply this change to Studio server files:  `~/Library/Application Support/Studio/server-files/sqlite-command/src/Import.php`
* Start Studio
* Go to the import tab
* Drag and drop a SQL malformed [fake.sql](https://github.com/user-attachments/files/22906401/fake-sql.sql)
* Observe the error in Studio

<img width="1012" height="712" alt="Screenshot 2025-10-14 at 14 54 39" src="https://github.com/user-attachments/assets/5ea29c44-a3ae-4137-9b10-da430cf2bcc9" />
