### PR TITLE
Set default SQL modes and other options for database import

### DIFF
--- a/features/sqlite-import.feature
+++ b/features/sqlite-import.feature
@@ -171,3 +171,23 @@ Feature: WP-CLI SQLite Import Command
 
     And the SQLite database should contain a table named "test_table"
     And the "test_table" should contain a row with name "Test Name"
+
+  @require-sqlite
+  Scenario: Import data that expect non-strict SQL mode to be set
+    Given a SQL dump file named "test_import.sql" with content:
+      """
+      CREATE TABLE test_table (
+        id INTEGER,
+        name TEXT NOT NULL,
+        created_at DATETIME DEFAULT '0000-00-00 00:00:00'
+      );
+      INSERT INTO test_table (id) VALUES (1);
+      """
+    When I run `wp sqlite --enable-ast-driver import test_import.sql`
+    Then STDOUT should contain:
+      """
+      Success: Imported from 'test_import.sql'.
+      """
+
+    And the SQLite database should contain a table named "test_table"
+    And the "test_table" should contain a row with name ""


### PR DESCRIPTION
Some backups don't include `SET SQL_MODE = …` statements, but they do rely on WordPress-compatible SQL modes to be set during import (which are different from MySQL defaults).

This works with `wp db import`, because the command [handles that for backups imported from files](https://github.com/wp-cli/db-command/blob/abeefa5a6c472f12716c5fa5c5a7394d3d0b1ef2/src/DB_Command.php#L823).

The new SQLite driver supports some SQL modes, but the `wp sqlite import` command doesn't set any defaults. This may cause some backups to fail to import into the SQLite database.

To fix this, we need to set permissive defaults for the `wp sqlite import` command, just like the native `mysqldump` command does.

Fixes https://github.com/WordPress/sqlite-database-integration/issues/253.