### PR TITLE
Include exception message in import error output

### DIFF
--- a/src/Import.php
+++ b/src/Import.php
@@ -84,8 +84,7 @@ class Import {
 						throw $e;
 					}
 				} catch ( Exception $e ) {
-					WP_CLI::error( 'Could not execute statement: ' . $statement );
-					echo $e->getMessage();
+					WP_CLI::error( 'Could not execute statement: ' . $statement . '. Error: ' . $e->getMessage() );
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

- Fixed bug where SQL import errors showed only the failing statement but not the actual error message
- `WP_CLI::error()` exits the process immediately, so the subsequent `echo $e->getMessage()` was dead code
- Now includes the exception message in the error output

## Problem

When importing a SQL file with syntax errors, users would see:

```
Error: Could not execute statement: INSERT INTO wp_options ...
```

But they wouldn't see **what** the actual error was (e.g., "syntax error near X").

## Solution

Include the exception message in the `WP_CLI::error()` call:

```php
// Before (dead code - echo never ran because WP_CLI::error exits)
WP_CLI::error( 'Could not execute statement: ' . $statement );
echo $e->getMessage();

// After
WP_CLI::error( 'Could not execute statement: ' . $statement . '. Error: ' . $e->getMessage() );
```

## Test plan

- [ ] Create a SQL file with invalid syntax (e.g., `INSERT INTO foo VALUES (unclosed parenthesis;`)
- [ ] Run `wp sqlite import invalid.sql`
- [ ] Verify the error message now includes the actual SQL error details

🤖 Generated with [Claude Code](https://claude.ai/code)