### PR TITLE
Use the new SQLite driver loader file when available

### DIFF
--- a/src/SQLiteDatabaseIntegrationLoader.php
+++ b/src/SQLiteDatabaseIntegrationLoader.php
@@ -88,7 +88,9 @@ final class SQLiteDatabaseIntegrationLoader {
 
 		$new_driver_enabled = defined( 'WP_SQLITE_AST_DRIVER' ) && WP_SQLITE_AST_DRIVER;
 
-		if ( $new_driver_enabled ) {
+		if ( $new_driver_enabled && file_exists( $plugin_directory . '/wp-pdo-mysql-on-sqlite.php' ) ) {
+			require_once $plugin_directory . '/wp-pdo-mysql-on-sqlite.php';
+		} elseif ( $new_driver_enabled ) {
 			require_once $plugin_directory . '/version.php';
 			require_once $plugin_directory . '/wp-includes/parser/class-wp-parser-grammar.php';
 			require_once $plugin_directory . '/wp-includes/parser/class-wp-parser.php';


### PR DESCRIPTION
## Summary

- The new SQLite driver now exposes `wp-pdo-mysql-on-sqlite.php` as a single entry point for loading. When the file is present, use it instead of manually requiring individual driver files.
- Falls back to the existing manual requires for older driver versions that don't ship the loader file.

This is needed so that the new driver files in the SQLite repository can be reorganized into a monorepo-like structure.