### PR TITLE
Upgrade wp-cli-tests to v5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,9 @@
     "wp-cli/wp-cli": "^2.5"
   },
   "require-dev": {
-    "wp-cli/wp-cli-tests": "^4.3.2",
-    "phpcompatibility/php-compatibility": "dev-develop"
+    "wp-cli/wp-cli-tests": "^5.0",
+    "phpcompatibility/php-compatibility": "^10.0@alpha",
+    "wp-coding-standards/wpcs": "@dev"
   },
   "scripts": {
     "behat": "run-behat-tests",
@@ -37,6 +38,7 @@
     "lint": "run-linter-tests",
     "phpcs": "run-phpcs-tests",
     "phpcbf": "run-phpcbf-cleanup",
+    "phpstan": "run-phpstan-tests",
     "phpunit": "run-php-unit-tests",
     "prepare-tests": "install-package-tests",
     "test": [
@@ -48,7 +50,8 @@
   },
   "config": {
     "allow-plugins": {
-      "dealerdirect/phpcodesniffer-composer-installer": true
+      "dealerdirect/phpcodesniffer-composer-installer": true,
+      "phpstan/extension-installer": true
     }
   }
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,15 @@
+parameters:
+  level: 0
+  paths:
+    - src
+    - command.php
+  scanDirectories:
+    - vendor/wp-cli/wp-cli/php
+  scanFiles:
+    - vendor/php-stubs/wordpress-stubs/wordpress-stubs.php
+    - phpstan/stubs.php
+  treatPhpDocTypesAsCertain: false
+  dynamicConstantNames:
+    - WP_DEBUG
+    - WP_DEBUG_LOG
+    - WP_DEBUG_DISPLAY

--- a/phpstan/stubs.php
+++ b/phpstan/stubs.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Stubs for the WordPress SQLite integration plugin classes.
+ *
+ * These classes are loaded at runtime by WordPress, not via Composer.
+ * The stubs allow PHPStan to analyze code that references them.
+ */
+
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound
+// phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
+// phpcs:disable PHPCompatibility.FunctionDeclarations.NewReturnTypeDeclarations
+// phpcs:disable PHPCompatibility.FunctionDeclarations.NewParamTypeDeclarations
+
+class WP_SQLite_Connection {
+	/**
+	 * @param array{path: string} $config
+	 */
+	public function __construct( array $config ) {}
+	public function quote_identifier( string $identifier ): string {}
+	public function get_pdo(): PDO {}
+}
+
+class WP_SQLite_Driver {
+	public function __construct( WP_SQLite_Connection $connection, string $db_name ) {}
+	public function query( string $sql ) {}
+	public function get_connection(): WP_SQLite_Connection {}
+}
+
+class WP_SQLite_Translator {
+	public function __construct() {}
+	public function query( string $sql ) {}
+	public function get_pdo(): PDO {}
+}


### PR DESCRIPTION
## Summary

The `dev-develop` branch of `phpcompatibility/php-compatibility` now requires `squizlabs/php_codesniffer ^4`, which conflicts with `^3` required by `wp-cli-tests v4`. This breaks all CI jobs. Additionally, the shared CI workflow ([wp-cli/.github#208](https://github.com/wp-cli/.github/pull/208)) now runs code coverage on PHP 8.5, which needs the newer `php-code-coverage` library from v5.

## Changes

- **Upgrade wp-cli-tests:** From `^4.3.2` to `^5.0`, resolving the codesniffer version conflict and adding PHP 8.5 coverage support.
- **Add transitive deps with stability flags:** `phpcompatibility/php-compatibility ^10.0@alpha` and `wp-coding-standards/wpcs @dev`, since these packages don't have stable releases compatible with codesniffer `^4` yet.
- **Add PHPStan config:** Required by `wp-cli-tests v5`. Starts at level 0 with stubs for `WP_SQLite_Driver`, `WP_SQLite_Translator`, and `WP_SQLite_Connection` (loaded at runtime by WordPress, not available via Composer).
- **Allow phpstan/extension-installer:** New Composer plugin required by `wp-cli-tests v5`.