### PR TITLE
Fix foreign key constraint errors during import

### DIFF
--- a/features/bootstrap/SQLiteFeatureContext.php
+++ b/features/bootstrap/SQLiteFeatureContext.php
@@ -3,7 +3,6 @@
 namespace Automattic\WP_CLI\SQLite;
 
 use Behat\Behat\Context\Context;
-use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\PyStringNode;
 use WP_CLI\Tests\Context\FeatureContext as WPCLIFeatureContext;
 use SQLite3;

--- a/features/sqlite-import.feature
+++ b/features/sqlite-import.feature
@@ -191,3 +191,24 @@ Feature: WP-CLI SQLite Import Command
 
     And the SQLite database should contain a table named "test_table"
     And the "test_table" should contain a row with name ""
+
+  @require-sqlite
+  Scenario: Import tables with foreign key constraints when child table is imported before parent
+    Given a SQL dump file named "test_import.sql" with content:
+      """
+      CREATE TABLE wp_aa_child (
+        id INTEGER PRIMARY KEY,
+        parent_id INTEGER NOT NULL,
+        CONSTRAINT fk_parent FOREIGN KEY (parent_id) REFERENCES wp_zz_parent(id)
+      );
+      INSERT INTO wp_aa_child (id, parent_id) VALUES (1, 1);
+      CREATE TABLE wp_zz_parent (id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+      INSERT INTO wp_zz_parent (id, name) VALUES (1, 'Parent Row');
+      """
+    When I run `wp sqlite --enable-ast-driver import test_import.sql`
+    Then STDOUT should contain:
+      """
+      Success: Imported from 'test_import.sql'.
+      """
+    And the SQLite database should contain a table named "wp_zz_parent"
+    And the SQLite database should contain a table named "wp_aa_child"

--- a/src/Import.php
+++ b/src/Import.php
@@ -49,7 +49,26 @@ class Import {
 		$this->driver->query( 'SET @BACKUP_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0' );
 		$this->driver->query( 'SET @BACKUP_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0' );
 
+		/*
+		 * Disable foreign key constraints at the SQLite level during import.
+		 *
+		 * The MySQL SET FOREIGN_KEY_CHECKS=0 above is stored as a session
+		 * variable by the driver but does not translate to SQLite's PRAGMA.
+		 * We need to explicitly disable foreign keys so that tables with
+		 * cross-references can be imported in any order (e.g., alphabetical).
+		 */
+		$this->driver->execute_sqlite_query( 'PRAGMA foreign_keys = OFF' );
+
 		$this->execute_statements( $import_file );
+
+		/*
+		 * Re-enable foreign key constraints and verify integrity.
+		 *
+		 * PRAGMA foreign_key_check validates all FK references after the
+		 * full import, catching any actual data integrity issues.
+		 */
+		$this->driver->execute_sqlite_query( 'PRAGMA foreign_key_check' );
+		$this->driver->execute_sqlite_query( 'PRAGMA foreign_keys = ON' );
 
 		$this->driver->query( 'SET SQL_MODE=@BACKUP_SQL_MODE' );
 		$this->driver->query( 'SET UNIQUE_CHECKS=@BACKUP_UNIQUE_CHECKS' );


### PR DESCRIPTION
Fixes STU-1485

## Summary

When importing SQL dumps where tables are processed in alphabetical order (as Studio does with Jetpack backups), any table containing a FOREIGN KEY constraint referencing another table that comes later alphabetically causes the import to fail with a SQLite constraint error.

For example, a backup containing `wp_cartflows_ca_email_history` (which has an FK to `wp_cartflows_ca_email_templates`) fails because `_email_history` is imported before `_email_templates`.

This affects any WordPress plugin that uses foreign key constraints between tables.

## Context

The import command already sets `SET FOREIGN_KEY_CHECKS=0`. However, the SQLite driver stores this as a PHP session variable, it does not translate it to SQLite’s equivalent `PRAGMA foreign_keys = OFF`. Both `WP_SQLite_Driver` and `WP_SQLite_Translator` enable `PRAGMA foreign_keys = ON` at initialization, so FK constraints remain enforced throughout the import regardless of the MySQL-level setting. 

## Changes

Use `execute_sqlite_query()` to explicitly set `PRAGMA foreign_keys = OFF` before the import and re-enable it afterward. After re-enabling, `PRAGMA foreign_key_check` validates all FK references, catching any actual data integrity issues.

## Testing

I prepared this test SQL dump where a child table with an FK constraint appears before its referenced parent table:
```
fk-test-backup
└── sql
    ├── wp_aa_child.sql
    └── wp_zz_parent.sql
```
[fk-test-backup.tar.gz](https://github.com/user-attachments/files/26061461/fk-test-backup.tar.gz)

* Run `wp sqlite import <fk-test-backup>`
* Before fix: import fails with constraint error on the INSERT into the child table
* After fix: import succeeds, both tables are created with correct data