### PR TITLE
Load polyfills correctly for the new sqlite version (v2.2.22)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,8 @@
       "email": "jeroen.pfeil@automattic.com"
     }
   ],
+  "minimum-stability": "dev",
+  "prefer-stable": true,
   "require": {
     "php": ">=7.4",
     "wp-cli/wp-cli": "^2.13"

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
   ],
   "require": {
     "php": ">=7.4",
-    "wp-cli/wp-cli": "^2.5"
+    "wp-cli/wp-cli": "^2.13"
   },
   "require-dev": {
     "wp-cli/wp-cli-tests": "^5.0",

--- a/features/bootstrap/SQLiteFeatureContext.php
+++ b/features/bootstrap/SQLiteFeatureContext.php
@@ -3,7 +3,6 @@
 namespace Automattic\WP_CLI\SQLite;
 
 use Behat\Behat\Context\Context;
-use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\PyStringNode;
 use WP_CLI\Tests\Context\FeatureContext as WPCLIFeatureContext;
 use SQLite3;

--- a/features/bootstrap/SQLiteFeatureContext.php
+++ b/features/bootstrap/SQLiteFeatureContext.php
@@ -5,7 +5,7 @@ namespace Automattic\WP_CLI\SQLite;
 use Behat\Behat\Context\Context;
 use Behat\Gherkin\Node\PyStringNode;
 use WP_CLI\Tests\Context\FeatureContext as WPCLIFeatureContext;
-use SQLite3;
+use PDO;
 use Exception;
 
 class SQLiteFeatureContext extends WPCLIFeatureContext implements Context {
@@ -24,8 +24,9 @@ class SQLiteFeatureContext extends WPCLIFeatureContext implements Context {
 	 */
 	public function theSqliteDatabaseShouldContainATableNamed( $table_name ) {
 		$this->connectToDatabase();
-		$result = $this->db->query( "SELECT name FROM sqlite_master WHERE type='table' AND name='" . $this->db->escapeString( $table_name ) . "'" );
-		$row    = $result->fetchArray();
+		$stmt = $this->db->prepare( "SELECT name FROM sqlite_master WHERE type='table' AND name=?" );
+		$stmt->execute( [ $table_name ] );
+		$row = $stmt->fetch();
 		if ( ! $row ) {
 			throw new Exception( "Table '$table_name' not found in the database." );
 		}
@@ -37,8 +38,9 @@ class SQLiteFeatureContext extends WPCLIFeatureContext implements Context {
 	 */
 	public function theTableShouldContainARowWithName( $table_name, $name ) {
 		$this->connectToDatabase();
-		$result = $this->db->query( "SELECT * FROM $table_name WHERE name='" . $this->db->escapeString( $name ) . "'" );
-		$row    = $result->fetchArray();
+		$stmt = $this->db->prepare( "SELECT * FROM $table_name WHERE name=?" );
+		$stmt->execute( [ $name ] );
+		$row = $stmt->fetch();
 		if ( ! $row ) {
 			throw new Exception( "Row with name '$name' not found in table '$table_name'." );
 		}
@@ -50,14 +52,7 @@ class SQLiteFeatureContext extends WPCLIFeatureContext implements Context {
 	public function theSqliteDatabaseShouldContainTheImportedData() {
 		$this->connectToDatabase();
 		$result = $this->db->query( "SELECT name FROM sqlite_master WHERE type='table'" );
-		$tables = [];
-		while ( true ) {
-			$row = $result->fetchArray();
-			if ( false === $row ) {
-				break;
-			}
-			$tables[] = $row['name'];
-		}
+		$tables = $result->fetchAll( PDO::FETCH_COLUMN );
 		if ( empty( $tables ) ) {
 			throw new Exception( 'No tables found in the database after import.' );
 		}
@@ -77,7 +72,8 @@ class SQLiteFeatureContext extends WPCLIFeatureContext implements Context {
 		if ( ! $this->db ) {
 			$run_dir  = $this->variables['RUN_DIR'];
 			$db_file  = $run_dir . '/wp-content/database/.ht.sqlite';
-			$this->db = new SQLite3( $db_file );
+			$this->db = new PDO( 'sqlite:' . $db_file );
+			$this->db->setAttribute( PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION );
 		}
 	}
 
@@ -104,45 +100,43 @@ class SQLiteFeatureContext extends WPCLIFeatureContext implements Context {
 		file_put_contents( $full_path, $content );
 	}
 
-
-	////
 	/**
 	 * @Given /^the SQLite database contains some sample data$/
 	 */
 	public function theSqliteDatabaseContainsSomeSampleData() {
-						$this->connectToDatabase();
-						$this->db->exec(
-							"
-									INSERT OR REPLACE INTO wp_posts (ID, post_title, post_content, post_type, post_status)
-									VALUES (1, 'Sample Post', 'This is a sample post content.', 'post', 'publish');
-							"
-						);
+		$this->connectToDatabase();
+		$this->db->exec(
+			"
+				INSERT OR REPLACE INTO wp_posts (ID, post_title, post_content, post_type, post_status)
+				VALUES (1, 'Sample Post', 'This is a sample post content.', 'post', 'publish');
+			"
+		);
 
-							// Insert or update sample data in wp_users
-							$this->db->exec(
-								"
-									INSERT OR REPLACE INTO wp_users (ID, user_login, user_pass, user_nicename, user_email)
-									VALUES (1, 'testuser', 'password_hash', 'Test User', 'testuser@example.com');
-							"
-							);
+		// Insert or update sample data in wp_users
+		$this->db->exec(
+			"
+				INSERT OR REPLACE INTO wp_users (ID, user_login, user_pass, user_nicename, user_email)
+				VALUES (1, 'testuser', 'password_hash', 'Test User', 'testuser@example.com');
+			"
+		);
 
-							// Insert or update sample data in wp_options
-							$this->db->exec(
-								"
-									INSERT OR REPLACE INTO wp_options (option_id, option_name, option_value, autoload)
-									VALUES
-									(1, 'siteurl', 'http://example.com', 'yes'),
-									(2, 'blogname', 'Test Blog', 'yes'),
-									(3, 'blogdescription', 'Just another WordPress site', 'yes'),
-									(4, 'users_can_register', '0', 'yes'),
-									(5, 'admin_email', 'admin@example.com', 'yes'),
-									(6, 'start_of_week', '1', 'yes'),
-									(7, 'use_balanceTags', '0', 'yes'),
-									(8, 'use_smilies', '1', 'yes'),
-									(9, 'require_name_email', '1', 'yes'),
-									(10, 'comments_notify', '1', 'yes');
-							"
-							);
+		// Insert or update sample data in wp_options
+		$this->db->exec(
+			"
+				INSERT OR REPLACE INTO wp_options (option_id, option_name, option_value, autoload)
+				VALUES
+				(1, 'siteurl', 'http://example.com', 'yes'),
+				(2, 'blogname', 'Test Blog', 'yes'),
+				(3, 'blogdescription', 'Just another WordPress site', 'yes'),
+				(4, 'users_can_register', '0', 'yes'),
+				(5, 'admin_email', 'admin@example.com', 'yes'),
+				(6, 'start_of_week', '1', 'yes'),
+				(7, 'use_balanceTags', '0', 'yes'),
+				(8, 'use_smilies', '1', 'yes'),
+				(9, 'require_name_email', '1', 'yes'),
+				(10, 'comments_notify', '1', 'yes');
+			"
+		);
 	}
 
 	/**

--- a/src/SQLiteDatabaseIntegrationLoader.php
+++ b/src/SQLiteDatabaseIntegrationLoader.php
@@ -89,12 +89,27 @@ final class SQLiteDatabaseIntegrationLoader {
 		}
 		require_once $plugin_directory . '/constants.php';
 
-		if ( $new_driver_enabled ) {
-			if ( file_exists( $plugin_directory . '/wp-pdo-mysql-on-sqlite.php' ) ) {
-				require_once $plugin_directory . '/wp-pdo-mysql-on-sqlite.php';
-			} elseif ( file_exists( $plugin_directory . '/wp-includes/database/load.php' ) ) {
-				require_once $plugin_directory . '/wp-includes/database/load.php';
-			}
+		if ( $new_driver_enabled && file_exists( $plugin_directory . '/wp-pdo-mysql-on-sqlite.php' ) ) {
+			require_once $plugin_directory . '/wp-pdo-mysql-on-sqlite.php';
+		} elseif ( $new_driver_enabled && file_exists( $plugin_directory . '/wp-includes/database/load.php' ) ) {
+			require_once $plugin_directory . '/wp-includes/database/load.php';
+		} elseif ( $new_driver_enabled ) {
+			require_once $plugin_directory . '/version.php';
+			require_once $plugin_directory . '/wp-includes/parser/class-wp-parser-grammar.php';
+			require_once $plugin_directory . '/wp-includes/parser/class-wp-parser.php';
+			require_once $plugin_directory . '/wp-includes/parser/class-wp-parser-node.php';
+			require_once $plugin_directory . '/wp-includes/parser/class-wp-parser-token.php';
+			require_once $plugin_directory . '/wp-includes/mysql/class-wp-mysql-token.php';
+			require_once $plugin_directory . '/wp-includes/mysql/class-wp-mysql-lexer.php';
+			require_once $plugin_directory . '/wp-includes/mysql/class-wp-mysql-parser.php';
+			require_once $plugin_directory . '/wp-includes/sqlite/class-wp-sqlite-pdo-user-defined-functions.php';
+			require_once $plugin_directory . '/wp-includes/sqlite-ast/class-wp-sqlite-connection.php';
+			require_once $plugin_directory . '/wp-includes/sqlite-ast/class-wp-sqlite-configurator.php';
+			require_once $plugin_directory . '/wp-includes/sqlite-ast/class-wp-sqlite-driver.php';
+			require_once $plugin_directory . '/wp-includes/sqlite-ast/class-wp-sqlite-driver-exception.php';
+			require_once $plugin_directory . '/wp-includes/sqlite-ast/class-wp-sqlite-information-schema-builder.php';
+			require_once $plugin_directory . '/wp-includes/sqlite-ast/class-wp-sqlite-information-schema-exception.php';
+			require_once $plugin_directory . '/wp-includes/sqlite-ast/class-wp-sqlite-information-schema-reconstructor.php';
 		} else {
 			$sqlite = $plugin_directory . '/wp-includes/sqlite';
 			require_once "$sqlite/class-wp-sqlite-lexer.php";

--- a/src/SQLiteDatabaseIntegrationLoader.php
+++ b/src/SQLiteDatabaseIntegrationLoader.php
@@ -83,7 +83,11 @@ final class SQLiteDatabaseIntegrationLoader {
 		}
 
 		// We also need to selectively load the necessary classes from the plugin.
-		require_once $plugin_directory . '/php-polyfills.php';
+		// In v2.2.22+, php-polyfills.php moved to wp-includes/database/php-polyfills.php.
+		$polyfills_path = file_exists( $plugin_directory . '/wp-includes/database/php-polyfills.php' )
+			? $plugin_directory . '/wp-includes/database/php-polyfills.php'
+			: $plugin_directory . '/php-polyfills.php';
+		require_once $polyfills_path;
 		require_once $plugin_directory . '/constants.php';
 
 		$new_driver_enabled = defined( 'WP_SQLITE_AST_DRIVER' ) && WP_SQLITE_AST_DRIVER;

--- a/src/SQLiteDatabaseIntegrationLoader.php
+++ b/src/SQLiteDatabaseIntegrationLoader.php
@@ -81,7 +81,7 @@ final class SQLiteDatabaseIntegrationLoader {
 			define( 'SQLITE_DB_DROPIN_VERSION', $sqlite_plugin_version ); // phpcs:ignore
 		}
 
-		// In v2.2.22+, files moved into wp-includes/database/ subdirectories.
+		// In v2.2.21+, files moved into wp-includes/database/ subdirectories.
 		$new_structure      = file_exists( $plugin_directory . '/wp-includes/database/php-polyfills.php' );
 		$new_driver_enabled = defined( 'WP_SQLITE_AST_DRIVER' ) && WP_SQLITE_AST_DRIVER;
 

--- a/src/SQLiteDatabaseIntegrationLoader.php
+++ b/src/SQLiteDatabaseIntegrationLoader.php
@@ -81,13 +81,12 @@ final class SQLiteDatabaseIntegrationLoader {
 			define( 'SQLITE_DB_DROPIN_VERSION', $sqlite_plugin_version ); // phpcs:ignore
 		}
 
-		// In v2.2.21+, files moved into wp-includes/database/ subdirectories.
-		$new_structure      = file_exists( $plugin_directory . '/wp-includes/database/php-polyfills.php' );
 		$new_driver_enabled = defined( 'WP_SQLITE_AST_DRIVER' ) && WP_SQLITE_AST_DRIVER;
+		$old_structure      = file_exists( $plugin_directory . '/php-polyfills.php' );
 
-		require_once $new_structure
-			? $plugin_directory . '/wp-includes/database/php-polyfills.php'
-			: $plugin_directory . '/php-polyfills.php';
+		if ( $old_structure ) {
+			require_once $plugin_directory . '/php-polyfills.php';
+		}
 		require_once $plugin_directory . '/constants.php';
 
 		if ( $new_driver_enabled ) {

--- a/src/SQLiteDatabaseIntegrationLoader.php
+++ b/src/SQLiteDatabaseIntegrationLoader.php
@@ -104,7 +104,7 @@ final class SQLiteDatabaseIntegrationLoader {
 	 * @param bool   $new_structure    Whether the plugin uses the v2.2.22+ directory structure.
 	 * @return void
 	 */
-	private static function load_ast_driver( string $plugin_directory, bool $new_structure ): void {
+	private static function load_ast_driver( $plugin_directory, $new_structure ) {
 		if ( file_exists( $plugin_directory . '/wp-pdo-mysql-on-sqlite.php' ) ) {
 			require_once $plugin_directory . '/wp-pdo-mysql-on-sqlite.php';
 			return;
@@ -122,7 +122,7 @@ final class SQLiteDatabaseIntegrationLoader {
 	 * @param bool   $new_structure    Whether the plugin uses the v2.2.22+ directory structure.
 	 * @return string[]
 	 */
-	private static function get_ast_driver_files( string $plugin_directory, bool $new_structure ): array {
+	private static function get_ast_driver_files( $plugin_directory, $new_structure ) {
 		if ( $new_structure ) {
 			$db = $plugin_directory . '/wp-includes/database';
 			return [
@@ -172,7 +172,7 @@ final class SQLiteDatabaseIntegrationLoader {
 	 * @param string $plugin_directory The plugin directory.
 	 * @return void
 	 */
-	private static function load_legacy_driver( string $plugin_directory ): void {
+	private static function load_legacy_driver( $plugin_directory ) {
 		$sqlite = $plugin_directory . '/wp-includes/sqlite';
 		require_once "$sqlite/class-wp-sqlite-lexer.php";
 		require_once "$sqlite/class-wp-sqlite-query-rewriter.php";

--- a/src/SQLiteDatabaseIntegrationLoader.php
+++ b/src/SQLiteDatabaseIntegrationLoader.php
@@ -76,65 +76,108 @@ final class SQLiteDatabaseIntegrationLoader {
 		if ( version_compare( $sqlite_plugin_version, '2.1.11', '<' ) ) {
 			WP_CLI::error( 'The SQLite integration plugin must be version 2.1.11 or higher.' );
 		}
-
 		// Load the translator class from the plugin.
 		if ( ! defined( 'SQLITE_DB_DROPIN_VERSION' ) ) {
 			define( 'SQLITE_DB_DROPIN_VERSION', $sqlite_plugin_version ); // phpcs:ignore
 		}
 
-		// We also need to selectively load the necessary classes from the plugin.
 		// In v2.2.22+, files moved into wp-includes/database/ subdirectories.
-		$new_structure = file_exists( $plugin_directory . '/wp-includes/database/php-polyfills.php' );
+		$new_structure      = file_exists( $plugin_directory . '/wp-includes/database/php-polyfills.php' );
+		$new_driver_enabled = defined( 'WP_SQLITE_AST_DRIVER' ) && WP_SQLITE_AST_DRIVER;
 
 		require_once $new_structure
 			? $plugin_directory . '/wp-includes/database/php-polyfills.php'
 			: $plugin_directory . '/php-polyfills.php';
 		require_once $plugin_directory . '/constants.php';
 
-		$new_driver_enabled = defined( 'WP_SQLITE_AST_DRIVER' ) && WP_SQLITE_AST_DRIVER;
-
-		if ( $new_driver_enabled && file_exists( $plugin_directory . '/wp-pdo-mysql-on-sqlite.php' ) ) {
-			require_once $plugin_directory . '/wp-pdo-mysql-on-sqlite.php';
-		} elseif ( $new_driver_enabled && $new_structure ) {
-			require_once $plugin_directory . '/wp-includes/database/version.php';
-			require_once $plugin_directory . '/wp-includes/database/parser/class-wp-parser-grammar.php';
-			require_once $plugin_directory . '/wp-includes/database/parser/class-wp-parser.php';
-			require_once $plugin_directory . '/wp-includes/database/parser/class-wp-parser-node.php';
-			require_once $plugin_directory . '/wp-includes/database/parser/class-wp-parser-token.php';
-			require_once $plugin_directory . '/wp-includes/database/mysql/class-wp-mysql-token.php';
-			require_once $plugin_directory . '/wp-includes/database/mysql/class-wp-mysql-lexer.php';
-			require_once $plugin_directory . '/wp-includes/database/mysql/class-wp-mysql-parser.php';
-			require_once $plugin_directory . '/wp-includes/database/sqlite/class-wp-sqlite-pdo-user-defined-functions.php';
-			require_once $plugin_directory . '/wp-includes/database/sqlite/class-wp-sqlite-connection.php';
-			require_once $plugin_directory . '/wp-includes/database/sqlite/class-wp-sqlite-configurator.php';
-			require_once $plugin_directory . '/wp-includes/database/sqlite/class-wp-sqlite-driver.php';
-			require_once $plugin_directory . '/wp-includes/database/sqlite/class-wp-sqlite-driver-exception.php';
-			require_once $plugin_directory . '/wp-includes/database/sqlite/class-wp-sqlite-information-schema-builder.php';
-			require_once $plugin_directory . '/wp-includes/database/sqlite/class-wp-sqlite-information-schema-exception.php';
-			require_once $plugin_directory . '/wp-includes/database/sqlite/class-wp-sqlite-information-schema-reconstructor.php';
-		} elseif ( $new_driver_enabled ) {
-			require_once $plugin_directory . '/version.php';
-			require_once $plugin_directory . '/wp-includes/parser/class-wp-parser-grammar.php';
-			require_once $plugin_directory . '/wp-includes/parser/class-wp-parser.php';
-			require_once $plugin_directory . '/wp-includes/parser/class-wp-parser-node.php';
-			require_once $plugin_directory . '/wp-includes/parser/class-wp-parser-token.php';
-			require_once $plugin_directory . '/wp-includes/mysql/class-wp-mysql-token.php';
-			require_once $plugin_directory . '/wp-includes/mysql/class-wp-mysql-lexer.php';
-			require_once $plugin_directory . '/wp-includes/mysql/class-wp-mysql-parser.php';
-			require_once $plugin_directory . '/wp-includes/sqlite/class-wp-sqlite-pdo-user-defined-functions.php';
-			require_once $plugin_directory . '/wp-includes/sqlite-ast/class-wp-sqlite-connection.php';
-			require_once $plugin_directory . '/wp-includes/sqlite-ast/class-wp-sqlite-configurator.php';
-			require_once $plugin_directory . '/wp-includes/sqlite-ast/class-wp-sqlite-driver.php';
-			require_once $plugin_directory . '/wp-includes/sqlite-ast/class-wp-sqlite-driver-exception.php';
-			require_once $plugin_directory . '/wp-includes/sqlite-ast/class-wp-sqlite-information-schema-builder.php';
-			require_once $plugin_directory . '/wp-includes/sqlite-ast/class-wp-sqlite-information-schema-exception.php';
-			require_once $plugin_directory . '/wp-includes/sqlite-ast/class-wp-sqlite-information-schema-reconstructor.php';
+		if ( $new_driver_enabled ) {
+			self::load_ast_driver( $plugin_directory, $new_structure );
 		} else {
-			require_once $plugin_directory . '/wp-includes/sqlite/class-wp-sqlite-lexer.php';
-			require_once $plugin_directory . '/wp-includes/sqlite/class-wp-sqlite-query-rewriter.php';
-			require_once $plugin_directory . '/wp-includes/sqlite/class-wp-sqlite-translator.php';
-			require_once $plugin_directory . '/wp-includes/sqlite/class-wp-sqlite-token.php';
-			require_once $plugin_directory . '/wp-includes/sqlite/class-wp-sqlite-pdo-user-defined-functions.php';
+			self::load_legacy_driver( $plugin_directory );
 		}
+	}
+
+	/**
+	 * Load the AST driver classes from the SQLite integration plugin.
+	 *
+	 * @param string $plugin_directory The plugin directory.
+	 * @param bool   $new_structure    Whether the plugin uses the v2.2.22+ directory structure.
+	 * @return void
+	 */
+	private static function load_ast_driver( string $plugin_directory, bool $new_structure ): void {
+		if ( file_exists( $plugin_directory . '/wp-pdo-mysql-on-sqlite.php' ) ) {
+			require_once $plugin_directory . '/wp-pdo-mysql-on-sqlite.php';
+			return;
+		}
+
+		foreach ( self::get_ast_driver_files( $plugin_directory, $new_structure ) as $file ) {
+			require_once $file;
+		}
+	}
+
+	/**
+	 * Return the list of AST driver files to load based on the plugin directory structure.
+	 *
+	 * @param string $plugin_directory The plugin directory.
+	 * @param bool   $new_structure    Whether the plugin uses the v2.2.22+ directory structure.
+	 * @return string[]
+	 */
+	private static function get_ast_driver_files( string $plugin_directory, bool $new_structure ): array {
+		if ( $new_structure ) {
+			$db = $plugin_directory . '/wp-includes/database';
+			return [
+				"$db/version.php",
+				"$db/parser/class-wp-parser-grammar.php",
+				"$db/parser/class-wp-parser.php",
+				"$db/parser/class-wp-parser-node.php",
+				"$db/parser/class-wp-parser-token.php",
+				"$db/mysql/class-wp-mysql-token.php",
+				"$db/mysql/class-wp-mysql-lexer.php",
+				"$db/mysql/class-wp-mysql-parser.php",
+				"$db/sqlite/class-wp-sqlite-pdo-user-defined-functions.php",
+				"$db/sqlite/class-wp-sqlite-connection.php",
+				"$db/sqlite/class-wp-sqlite-configurator.php",
+				"$db/sqlite/class-wp-sqlite-driver.php",
+				"$db/sqlite/class-wp-sqlite-driver-exception.php",
+				"$db/sqlite/class-wp-sqlite-information-schema-builder.php",
+				"$db/sqlite/class-wp-sqlite-information-schema-exception.php",
+				"$db/sqlite/class-wp-sqlite-information-schema-reconstructor.php",
+			];
+		}
+
+		$wp = $plugin_directory . '/wp-includes';
+		return [
+			$plugin_directory . '/version.php',
+			"$wp/parser/class-wp-parser-grammar.php",
+			"$wp/parser/class-wp-parser.php",
+			"$wp/parser/class-wp-parser-node.php",
+			"$wp/parser/class-wp-parser-token.php",
+			"$wp/mysql/class-wp-mysql-token.php",
+			"$wp/mysql/class-wp-mysql-lexer.php",
+			"$wp/mysql/class-wp-mysql-parser.php",
+			"$wp/sqlite/class-wp-sqlite-pdo-user-defined-functions.php",
+			"$wp/sqlite-ast/class-wp-sqlite-connection.php",
+			"$wp/sqlite-ast/class-wp-sqlite-configurator.php",
+			"$wp/sqlite-ast/class-wp-sqlite-driver.php",
+			"$wp/sqlite-ast/class-wp-sqlite-driver-exception.php",
+			"$wp/sqlite-ast/class-wp-sqlite-information-schema-builder.php",
+			"$wp/sqlite-ast/class-wp-sqlite-information-schema-exception.php",
+			"$wp/sqlite-ast/class-wp-sqlite-information-schema-reconstructor.php",
+		];
+	}
+
+	/**
+	 * Load the legacy driver classes from the SQLite integration plugin.
+	 *
+	 * @param string $plugin_directory The plugin directory.
+	 * @return void
+	 */
+	private static function load_legacy_driver( string $plugin_directory ): void {
+		$sqlite = $plugin_directory . '/wp-includes/sqlite';
+		require_once "$sqlite/class-wp-sqlite-lexer.php";
+		require_once "$sqlite/class-wp-sqlite-query-rewriter.php";
+		require_once "$sqlite/class-wp-sqlite-translator.php";
+		require_once "$sqlite/class-wp-sqlite-token.php";
+		require_once "$sqlite/class-wp-sqlite-pdo-user-defined-functions.php";
 	}
 }

--- a/src/SQLiteDatabaseIntegrationLoader.php
+++ b/src/SQLiteDatabaseIntegrationLoader.php
@@ -83,17 +83,35 @@ final class SQLiteDatabaseIntegrationLoader {
 		}
 
 		// We also need to selectively load the necessary classes from the plugin.
-		// In v2.2.22+, php-polyfills.php moved to wp-includes/database/php-polyfills.php.
-		$polyfills_path = file_exists( $plugin_directory . '/wp-includes/database/php-polyfills.php' )
+		// In v2.2.22+, files moved into wp-includes/database/ subdirectories.
+		$new_structure = file_exists( $plugin_directory . '/wp-includes/database/php-polyfills.php' );
+
+		require_once $new_structure
 			? $plugin_directory . '/wp-includes/database/php-polyfills.php'
 			: $plugin_directory . '/php-polyfills.php';
-		require_once $polyfills_path;
 		require_once $plugin_directory . '/constants.php';
 
 		$new_driver_enabled = defined( 'WP_SQLITE_AST_DRIVER' ) && WP_SQLITE_AST_DRIVER;
 
 		if ( $new_driver_enabled && file_exists( $plugin_directory . '/wp-pdo-mysql-on-sqlite.php' ) ) {
 			require_once $plugin_directory . '/wp-pdo-mysql-on-sqlite.php';
+		} elseif ( $new_driver_enabled && $new_structure ) {
+			require_once $plugin_directory . '/wp-includes/database/version.php';
+			require_once $plugin_directory . '/wp-includes/database/parser/class-wp-parser-grammar.php';
+			require_once $plugin_directory . '/wp-includes/database/parser/class-wp-parser.php';
+			require_once $plugin_directory . '/wp-includes/database/parser/class-wp-parser-node.php';
+			require_once $plugin_directory . '/wp-includes/database/parser/class-wp-parser-token.php';
+			require_once $plugin_directory . '/wp-includes/database/mysql/class-wp-mysql-token.php';
+			require_once $plugin_directory . '/wp-includes/database/mysql/class-wp-mysql-lexer.php';
+			require_once $plugin_directory . '/wp-includes/database/mysql/class-wp-mysql-parser.php';
+			require_once $plugin_directory . '/wp-includes/database/sqlite/class-wp-sqlite-pdo-user-defined-functions.php';
+			require_once $plugin_directory . '/wp-includes/database/sqlite/class-wp-sqlite-connection.php';
+			require_once $plugin_directory . '/wp-includes/database/sqlite/class-wp-sqlite-configurator.php';
+			require_once $plugin_directory . '/wp-includes/database/sqlite/class-wp-sqlite-driver.php';
+			require_once $plugin_directory . '/wp-includes/database/sqlite/class-wp-sqlite-driver-exception.php';
+			require_once $plugin_directory . '/wp-includes/database/sqlite/class-wp-sqlite-information-schema-builder.php';
+			require_once $plugin_directory . '/wp-includes/database/sqlite/class-wp-sqlite-information-schema-exception.php';
+			require_once $plugin_directory . '/wp-includes/database/sqlite/class-wp-sqlite-information-schema-reconstructor.php';
 		} elseif ( $new_driver_enabled ) {
 			require_once $plugin_directory . '/version.php';
 			require_once $plugin_directory . '/wp-includes/parser/class-wp-parser-grammar.php';

--- a/src/SQLiteDatabaseIntegrationLoader.php
+++ b/src/SQLiteDatabaseIntegrationLoader.php
@@ -91,93 +91,18 @@ final class SQLiteDatabaseIntegrationLoader {
 		require_once $plugin_directory . '/constants.php';
 
 		if ( $new_driver_enabled ) {
-			self::load_ast_driver( $plugin_directory, $new_structure );
+			if ( file_exists( $plugin_directory . '/wp-pdo-mysql-on-sqlite.php' ) ) {
+				require_once $plugin_directory . '/wp-pdo-mysql-on-sqlite.php';
+			} elseif ( file_exists( $plugin_directory . '/wp-includes/database/load.php' ) ) {
+				require_once $plugin_directory . '/wp-includes/database/load.php';
+			}
 		} else {
-			self::load_legacy_driver( $plugin_directory );
+			$sqlite = $plugin_directory . '/wp-includes/sqlite';
+			require_once "$sqlite/class-wp-sqlite-lexer.php";
+			require_once "$sqlite/class-wp-sqlite-query-rewriter.php";
+			require_once "$sqlite/class-wp-sqlite-translator.php";
+			require_once "$sqlite/class-wp-sqlite-token.php";
+			require_once "$sqlite/class-wp-sqlite-pdo-user-defined-functions.php";
 		}
-	}
-
-	/**
-	 * Load the AST driver classes from the SQLite integration plugin.
-	 *
-	 * @param string $plugin_directory The plugin directory.
-	 * @param bool   $new_structure    Whether the plugin uses the v2.2.22+ directory structure.
-	 * @return void
-	 */
-	private static function load_ast_driver( $plugin_directory, $new_structure ) {
-		if ( file_exists( $plugin_directory . '/wp-pdo-mysql-on-sqlite.php' ) ) {
-			require_once $plugin_directory . '/wp-pdo-mysql-on-sqlite.php';
-			return;
-		}
-
-		foreach ( self::get_ast_driver_files( $plugin_directory, $new_structure ) as $file ) {
-			require_once $file;
-		}
-	}
-
-	/**
-	 * Return the list of AST driver files to load based on the plugin directory structure.
-	 *
-	 * @param string $plugin_directory The plugin directory.
-	 * @param bool   $new_structure    Whether the plugin uses the v2.2.22+ directory structure.
-	 * @return string[]
-	 */
-	private static function get_ast_driver_files( $plugin_directory, $new_structure ) {
-		if ( $new_structure ) {
-			$db = $plugin_directory . '/wp-includes/database';
-			return [
-				"$db/version.php",
-				"$db/parser/class-wp-parser-grammar.php",
-				"$db/parser/class-wp-parser.php",
-				"$db/parser/class-wp-parser-node.php",
-				"$db/parser/class-wp-parser-token.php",
-				"$db/mysql/class-wp-mysql-token.php",
-				"$db/mysql/class-wp-mysql-lexer.php",
-				"$db/mysql/class-wp-mysql-parser.php",
-				"$db/sqlite/class-wp-sqlite-pdo-user-defined-functions.php",
-				"$db/sqlite/class-wp-sqlite-connection.php",
-				"$db/sqlite/class-wp-sqlite-configurator.php",
-				"$db/sqlite/class-wp-sqlite-driver.php",
-				"$db/sqlite/class-wp-sqlite-driver-exception.php",
-				"$db/sqlite/class-wp-sqlite-information-schema-builder.php",
-				"$db/sqlite/class-wp-sqlite-information-schema-exception.php",
-				"$db/sqlite/class-wp-sqlite-information-schema-reconstructor.php",
-			];
-		}
-
-		$wp = $plugin_directory . '/wp-includes';
-		return [
-			$plugin_directory . '/version.php',
-			"$wp/parser/class-wp-parser-grammar.php",
-			"$wp/parser/class-wp-parser.php",
-			"$wp/parser/class-wp-parser-node.php",
-			"$wp/parser/class-wp-parser-token.php",
-			"$wp/mysql/class-wp-mysql-token.php",
-			"$wp/mysql/class-wp-mysql-lexer.php",
-			"$wp/mysql/class-wp-mysql-parser.php",
-			"$wp/sqlite/class-wp-sqlite-pdo-user-defined-functions.php",
-			"$wp/sqlite-ast/class-wp-sqlite-connection.php",
-			"$wp/sqlite-ast/class-wp-sqlite-configurator.php",
-			"$wp/sqlite-ast/class-wp-sqlite-driver.php",
-			"$wp/sqlite-ast/class-wp-sqlite-driver-exception.php",
-			"$wp/sqlite-ast/class-wp-sqlite-information-schema-builder.php",
-			"$wp/sqlite-ast/class-wp-sqlite-information-schema-exception.php",
-			"$wp/sqlite-ast/class-wp-sqlite-information-schema-reconstructor.php",
-		];
-	}
-
-	/**
-	 * Load the legacy driver classes from the SQLite integration plugin.
-	 *
-	 * @param string $plugin_directory The plugin directory.
-	 * @return void
-	 */
-	private static function load_legacy_driver( $plugin_directory ) {
-		$sqlite = $plugin_directory . '/wp-includes/sqlite';
-		require_once "$sqlite/class-wp-sqlite-lexer.php";
-		require_once "$sqlite/class-wp-sqlite-query-rewriter.php";
-		require_once "$sqlite/class-wp-sqlite-translator.php";
-		require_once "$sqlite/class-wp-sqlite-token.php";
-		require_once "$sqlite/class-wp-sqlite-pdo-user-defined-functions.php";
 	}
 }


### PR DESCRIPTION
Closes STU-1529

 In `v2.2.22+` for the `sqlite-database-integration`, `php-polyfills.php` moved to `wp-includes/database/php-polyfills.php`. If you try to push a newly created site in Studio with that version, it will immediately fail due not being able to load `php-polyfills.php`. This PR adds a backwards compatible fix for it.

**Testing instructions**

* Create a new site in Studio (does not matter with which PHP version)
* Connect WP.com site
* Try pushing the site
* Confirm that the push fails 
---- 
* Copy the fixed SQLiteDatabaseIntegrationLoader.php from this branch to  `~/.studio/server-files/sqlite-command/src/SQLiteDatabaseIntegrationLoader.php`
 * Pin the version to prevent the app from overwriting your changes on restart: set the contents of `~/.studio/server-files/sqlite-command/version` to `v99.99.99`                                              
* Restart Studio                                                             
* Create a new site with any PHP version (you can use PHP 8.5 for good measure)
* Go to the `Sync` tab
* Connect a WP.com site
* Start the push process
* Confirm there are no errors due to loading polyfills (there will be another error in PHP 8.5 - all other versions will work fine with this fix -  related to deprecated warning but it will be solved in a different Studio PR)
* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * 