### PR TITLE
Ensure we use a stable composer version

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -12,3 +12,4 @@ jobs:
     uses: wp-cli/.github/.github/workflows/reusable-testing.yml@main
     with:
       minimum-php: "7.4"
+      matrix: '{ "exclude": [{ "os": "windows-latest" }] }'

--- a/composer.json
+++ b/composer.json
@@ -23,11 +23,9 @@
       "email": "jeroen.pfeil@automattic.com"
     }
   ],
-  "minimum-stability": "dev",
-  "prefer-stable": true,
   "require": {
     "php": ">=7.4",
-    "wp-cli/wp-cli": "^2.13"
+    "wp-cli/wp-cli": "^2.12"
   },
   "require-dev": {
     "wp-cli/wp-cli-tests": "^5.0",
@@ -54,6 +52,9 @@
     "allow-plugins": {
       "dealerdirect/phpcodesniffer-composer-installer": true,
       "phpstan/extension-installer": true
+    },
+    "platform": {
+      "php": "8.3"
     }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
       "phpstan/extension-installer": true
     },
     "platform": {
-      "php": "8.3"
+      "php": "7.4"
     }
   }
 }


### PR DESCRIPTION
In https://github.com/Automattic/wp-cli-sqlite-command/pull/24, I updated the `wp-cli/wp-cli` in the composer to `2.13` to ensure that tests pass but this created an issue with pulling and pushing sites in Studio:

* `vendor/wp-cli/wp-cli` vendored inside `sqlite-command` was a dev build of 2.13, which
  added `check_global_arg_conflicts()` — but the WP-CLI phar  `(~/.studio/server-files/wp-cli.phar)` is stable 2.12.0 which lacks that method              
*  `vendor/composer/platform_check.php` required PHP >= 8.4.0, but WASM runs PHP 8.3.30

In this PR, we are:

* downgrading the composer version to `2.12` which is a stable version
* adding platform check to be `8.3.0`

**To test the fix**

* Pull the changes from this branch
* Then, copy the files by running `rsync -a --exclude='.git' /path/to/wp-cli-sqlite-command/                                  
  ~/.studio/server-files/sqlite-command/`
* Make sure to update `path` in the command above
* Restart Studio
* Navigate to the `Sync` tab
* Connect a WP.com site
* Try pulling a site
* Confirm it succeeds                                                                         

