### PR TITLE
Update path and version inferring to work in Playground managed SQLite

### DIFF
--- a/src/SQLiteDatabaseIntegrationLoader.php
+++ b/src/SQLiteDatabaseIntegrationLoader.php
@@ -12,28 +12,19 @@ final class SQLiteDatabaseIntegrationLoader {
 	 * @return false|string The version of the SQLite integration plugin or false if not found/activated.
 	 */
 	public static function get_plugin_version() {
-		// Check if there is a db.php file in the wp-content directory.
-		if ( ! file_exists( ABSPATH . '/wp-content/db.php' ) ) {
-			return false;
-		}
-
-		// If the file is found, we need to check that it is the sqlite integration plugin.
-		$plugin_file = file_get_contents( ABSPATH . '/wp-content/db.php' );
-		if ( ! preg_match( '/define\( \'SQLITE_DB_DROPIN_VERSION\', \'([0-9.]+)\' \)/', $plugin_file ) ) {
-			return false;
-		}
-
 		$plugin_path = self::get_plugin_directory();
 		if ( ! $plugin_path ) {
 			return false;
 		}
 
-		// Try to get the version number from readme.txt
-		$plugin_file = file_get_contents( $plugin_path . '/readme.txt' );
+		$version_file = $plugin_path . '/wp-includes/database/version.php';
+		if ( ! file_exists( $version_file ) ) {
+			return false;
+		}
 
-		preg_match( '/^Stable tag:\s*?(.+)$/m', $plugin_file, $matches );
+		require_once $version_file;
 
-		return isset( $matches[1] ) ? trim( $matches[1] ) : false;
+		return defined( 'SQLITE_DRIVER_VERSION' ) ? SQLITE_DRIVER_VERSION : false;
 	}
 
 	/**
@@ -45,6 +36,7 @@ final class SQLiteDatabaseIntegrationLoader {
 		$plugin_folders = [
 			ABSPATH . '/wp-content/plugins/sqlite-database-integration',
 			ABSPATH . '/wp-content/mu-plugins/sqlite-database-integration',
+			'/internal/shared/sqlite-database-integration',
 		];
 
 		foreach ( $plugin_folders as $folder ) {

--- a/src/SQLiteDatabaseIntegrationLoader.php
+++ b/src/SQLiteDatabaseIntegrationLoader.php
@@ -78,6 +78,7 @@ final class SQLiteDatabaseIntegrationLoader {
 			require_once $plugin_directory . '/wp-includes/sqlite-ast/class-wp-sqlite-information-schema-exception.php';
 			require_once $plugin_directory . '/wp-includes/sqlite-ast/class-wp-sqlite-information-schema-reconstructor.php';
 		} else {
+			require_once $plugin_directory . '/wp-includes/database/version.php';
 			$sqlite = $plugin_directory . '/wp-includes/sqlite';
 			require_once "$sqlite/class-wp-sqlite-lexer.php";
 			require_once "$sqlite/class-wp-sqlite-query-rewriter.php";

--- a/src/SQLiteDatabaseIntegrationLoader.php
+++ b/src/SQLiteDatabaseIntegrationLoader.php
@@ -12,18 +12,6 @@ final class SQLiteDatabaseIntegrationLoader {
 	 * @return false|string The version of the SQLite integration plugin or false if not found/activated.
 	 */
 	public static function get_plugin_version() {
-		$plugin_path = self::get_plugin_directory();
-		if ( ! $plugin_path ) {
-			return false;
-		}
-
-		$version_file = $plugin_path . '/wp-includes/database/version.php';
-		if ( ! file_exists( $version_file ) ) {
-			return false;
-		}
-
-		require_once $version_file;
-
 		return defined( 'SQLITE_DRIVER_VERSION' ) ? SQLITE_DRIVER_VERSION : false;
 	}
 
@@ -58,19 +46,6 @@ final class SQLiteDatabaseIntegrationLoader {
 		$plugin_directory = self::get_plugin_directory();
 		if ( ! $plugin_directory ) {
 			WP_CLI::error( 'Could not locate the SQLite integration plugin.' );
-		}
-
-		$sqlite_plugin_version = self::get_plugin_version();
-		if ( ! $sqlite_plugin_version ) {
-			WP_CLI::error( 'Could not determine the version of the SQLite integration plugin.' );
-		}
-
-		if ( version_compare( $sqlite_plugin_version, '2.1.11', '<' ) ) {
-			WP_CLI::error( 'The SQLite integration plugin must be version 2.1.11 or higher.' );
-		}
-		// Load the translator class from the plugin.
-		if ( ! defined( 'SQLITE_DB_DROPIN_VERSION' ) ) {
-			define( 'SQLITE_DB_DROPIN_VERSION', $sqlite_plugin_version ); // phpcs:ignore
 		}
 
 		$new_driver_enabled = defined( 'WP_SQLITE_AST_DRIVER' ) && WP_SQLITE_AST_DRIVER;
@@ -109,6 +84,15 @@ final class SQLiteDatabaseIntegrationLoader {
 			require_once "$sqlite/class-wp-sqlite-translator.php";
 			require_once "$sqlite/class-wp-sqlite-token.php";
 			require_once "$sqlite/class-wp-sqlite-pdo-user-defined-functions.php";
+		}
+
+		$sqlite_plugin_version = self::get_plugin_version();
+		if ( ! $sqlite_plugin_version ) {
+			WP_CLI::error( 'Could not determine the version of the SQLite integration plugin.' );
+		}
+
+		if ( version_compare( $sqlite_plugin_version, '2.2.0', '<' ) ) {
+			WP_CLI::error( 'The SQLite integration plugin must be version 2.2.0 or higher.' );
 		}
 	}
 }


### PR DESCRIPTION
I propose to:
- add `/internal/shared/` to `get_plugin_directory()` to support Playground's in-memory VFS
- replace `get_plugin_version()` implementation to read from `SQLITE_DRIVER_VERSION ` constant instead of db.php