### PR TITLE
chore: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      actions-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           php-version: '8.1'
 

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -9,4 +9,4 @@ on:
 
 jobs:
   code-quality:
-    uses: wp-cli/.github/.github/workflows/reusable-code-quality.yml@main
+    uses: wp-cli/.github/.github/workflows/reusable-code-quality.yml@5a55e811a46f1ac4946dbd337b74ea7f23ebe014 # main

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    uses: wp-cli/.github/.github/workflows/reusable-testing.yml@main
+    uses: wp-cli/.github/.github/workflows/reusable-testing.yml@5a55e811a46f1ac4946dbd337b74ea7f23ebe014 # main
     with:
       minimum-php: "7.4"
       matrix: '{ "exclude": [{ "os": "windows-latest" }] }'


### PR DESCRIPTION
Pins third-party GitHub Actions in this repo to immutable commit SHAs.

This PR was prepared with agent assistance and manually verified.

Tracking: DEVPROD-1072

Repo-level summary:
- Pinned distinct third-party action refs in this PR: 3
- Repo-level unpinned usage count from the trunk recheck: 3
- Dependabot GitHub Actions coverage: created (.github/dependabot.yml)


Verification commands:

```bash
# shivammathur/setup-php # 2.37.1 -> 7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc
gh api repos/shivammathur/setup-php/commits/2.37.1 --jq '.sha'
# expected: 7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc

# wp-cli/.github/.github/workflows/reusable-code-quality.yml # main -> 5a55e811a46f1ac4946dbd337b74ea7f23ebe014
gh api repos/wp-cli/.github/commits/main --jq '.sha'
# expected: 5a55e811a46f1ac4946dbd337b74ea7f23ebe014

# wp-cli/.github/.github/workflows/reusable-testing.yml # main -> 5a55e811a46f1ac4946dbd337b74ea7f23ebe014
gh api repos/wp-cli/.github/commits/main --jq '.sha'
# expected: 5a55e811a46f1ac4946dbd337b74ea7f23ebe014
```
